### PR TITLE
Potential fix for code scanning alert no. 18: Inefficient regular expression

### DIFF
--- a/resources/scripts/lib/formatters.ts
+++ b/resources/scripts/lib/formatters.ts
@@ -27,8 +27,8 @@ function bytesToString(bytes: number, decimals = 2): string {
  * Formats an IPv4 or IPv6 address.
  */
 function ip(value: string): string {
-    // noinspection RegExpSimplifiable
-    return /([a-f0-9:]+:+)+[a-f0-9]+/.test(value) ? `[${value}]` : value;
+    // Efficient IPv6 regex avoids ambiguous backtracking
+    return /^(([a-f0-9]{1,4}:){7}[a-f0-9]{1,4}|(([a-f0-9]{1,4}:){1,7}:)|(([a-f0-9]{1,4}:){1,6}:[a-f0-9]{1,4})|(([a-f0-9]{1,4}:){1,5}(:[a-f0-9]{1,4}){1,2})|(([a-f0-9]{1,4}:){1,4}(:[a-f0-9]{1,4}){1,3})|(([a-f0-9]{1,4}:){1,3}(:[a-f0-9]{1,4}){1,4})|(([a-f0-9]{1,4}:){1,2}(:[a-f0-9]{1,4}){1,5})|([a-f0-9]{1,4}:)((:[a-f0-9]{1,4}){1,6})|(:((:[a-f0-9]{1,4}){1,7}|:)))(%[0-9a-zA-Z]{1,})?$/.test(value) ? `[${value}]` : value;
 }
 
 export { ip, mbToBytes, bytesToString };


### PR DESCRIPTION
Potential fix for [https://github.com/reviactyl/panel/security/code-scanning/18](https://github.com/reviactyl/panel/security/code-scanning/18)

The fix is to rewrite the regular expression inside the `ip()` function to remove the ambiguity caused by overlapping repetitions and alternatives involving colons. The goal of the regex is to detect IPv6 addresses, which use colons and hexadecimal characters. The ambiguity comes from the `([a-f0-9:]+:+)+[a-f0-9]+` part, where both `+` repetitions and alternatives can match the same colons, leading to exponential backtracking. To address this, we should use a more efficient IPv6-matching pattern that clearly separates repetitions and avoids ambiguous alternation. A good approach is to use `([a-f0-9]{1,4}:){2,7}[a-f0-9]{1,4}` for IPv6 fragments, or to use a well-known efficient IPv6 regex variant that matches standard formatting.  
The change needs to be made in `resources/scripts/lib/formatters.ts` on line 31, inside the `ip()` function, replacing the current regex pattern with an efficient alternative that avoids ambiguous repetition and matches valid IPv6 addresses. No changes to imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
