### PR TITLE
fix: docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ FROM --platform=$TARGETOS/$TARGETARCH php:8.3-fpm-alpine
 WORKDIR /app
 COPY . ./
 COPY --from=0 /app/public/assets ./public/assets
-RUN apk add --no-cache --update ca-certificates dcron curl git supervisor tar unzip nginx libpng-dev libxml2-dev libzip-dev certbot certbot-nginx \
+RUN apk add --no-cache --update ca-certificates dcron curl git supervisor tar unzip nginx libpng-dev libxml2-dev libzip-dev certbot certbot-nginx freetype-dev libjpeg-turbo-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-configure zip \
     && docker-php-ext-install bcmath gd pdo_mysql zip \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ FROM --platform=$TARGETOS/$TARGETARCH php:8.3-fpm-alpine
 WORKDIR /app
 COPY . ./
 COPY --from=0 /app/public/assets ./public/assets
-RUN apk add --no-cache --update ca-certificates dcron curl git supervisor tar unzip nginx libpng-dev libxml2-dev libzip-dev certbot certbot-nginx freetype-dev libjpeg-turbo-dev \
+RUN apk add --no-cache --update ca-certificates dcron curl git supervisor tar unzip nginx libpng-dev libxml2-dev libzip-dev certbot certbot-nginx freetype-dev libjpeg-turbo-dev icu-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-configure zip \
-    && docker-php-ext-install bcmath gd pdo_mysql zip \
+    && docker-php-ext-install bcmath gd intl pdo_mysql zip \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && cp .env.example .env \
     && mkdir -p bootstrap/cache/ storage/logs storage/framework/sessions storage/framework/views storage/framework/cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 # Build the assets that are needed for the frontend. This build stage is then discarded
 # since we won't need NodeJS anymore in the future. This Docker image ships a final production
 # level distribution of Reviactyl.
-FROM --platform=$TARGETOS/$TARGETARCH node:22-alpine
+# Use BUILDPLATFORM to run Node.js natively (avoids QEMU emulation issues)
+FROM --platform=$BUILDPLATFORM node:22-alpine
 WORKDIR /app
 COPY . ./
 RUN yarn install --frozen-lockfile \


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve multi-platform build reliability and enhance PHP image capabilities. The main changes focus on ensuring native builds for Node.js and expanding PHP's image support for image processing and internationalization.

**Build process improvements:**

* Changed the Node.js build stage to use `--platform=$BUILDPLATFORM` instead of `--platform=$TARGETOS/$TARGETARCH`, ensuring Node.js runs natively during builds and avoiding QEMU emulation issues. (`Dockerfile`)

**PHP image enhancements:**

* Added additional Alpine packages (`freetype-dev`, `libjpeg-turbo-dev`, `icu-dev`) to support image processing and internationalization in PHP. (`Dockerfile`)
* Updated PHP extension configuration to enable `gd` with freetype and jpeg support, and installed the `intl` extension for internationalization. (`Dockerfile`)