### PR TITLE
Fix Gravatar display in activity log (Fixes #123)

### DIFF
--- a/resources/scripts/components/elements/activity/ActivityLogEntry.tsx
+++ b/resources/scripts/components/elements/activity/ActivityLogEntry.tsx
@@ -50,7 +50,7 @@ export default ({ activity, children }: Props) => {
         <div className={'grid grid-cols-10 py-4 border-b-2 border-gray-800 last:rounded-b last:border-0 group'}>
             <div className={'hidden sm:flex sm:col-span-1 items-center justify-center select-none'}>
                 <div className={'flex items-center w-10 h-10 rounded-full bg-gray-600 overflow-hidden'}>
-                    <Avatar email={actor?.uuid || 'system'} />
+                    <Avatar email={actor?.email || (actor?.uuid === 'system' ? 'system' : undefined)} />
                 </div>
             </div>
             <div className={'col-span-10 sm:col-span-9 flex'}>

--- a/resources/scripts/reviactyl/ui/Avatar.tsx
+++ b/resources/scripts/reviactyl/ui/Avatar.tsx
@@ -9,10 +9,17 @@ interface Props {
 
 export default ({ email, className }: Props) => {
     const useremail = useStoreState((state) => state.user.data?.email);
+    
+    // Use provided email, fallback to current user email, or system default
+    const emailToUse = email || useremail || 'system@localhost';
+    
+    // For system users, use a consistent hash
+    const gravatarHash = email === 'system' ? '00000000000000000000000000000000' : Md5(String(emailToUse));
+    
     return (
         <img
-            src={`https://www.gravatar.com/avatar/${Md5(String(email ? email : useremail))}`}
-            className={`${className} + rounded-full`}
+            src={`https://www.gravatar.com/avatar/${gravatarHash}?d=identicon&s=40`}
+            className={`${className} rounded-full`}
             alt='Gravatar'
         />
     );


### PR DESCRIPTION
- Fix ActivityLogEntry to pass actor email instead of UUID to Avatar component
- Enhance Avatar component to handle system users and missing emails gracefully
- Add proper Gravatar parameters for consistent sizing and fallback avatars
- System users now get consistent identicon avatars
- User Gravatars now correctly display using email-based MD5 hashes

Resolves: https://github.com/reviactyl/panel/issues/123