### PR TITLE
feat: add default panel language setting (closes #21)

### DIFF
--- a/app/Filament/Pages/Settings.php
+++ b/app/Filament/Pages/Settings.php
@@ -20,6 +20,7 @@ use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Console\Kernel;
 use App\Contracts\Repository\SettingsRepositoryInterface;
+use App\Traits\Helpers\AvailableLanguages;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Encryption\DecryptException;
@@ -29,6 +30,7 @@ class Settings extends Page implements HasSchemas
 {
     use InteractsWithForms;
     use InteractsWithHeaderActions;
+    use AvailableLanguages;
 
     protected static string|\BackedEnum|null $navigationIcon = 'tabler-settings';
     protected static string|\BackedEnum|null $activeNavigationIcon = 'tabler-settings-filled';
@@ -187,6 +189,21 @@ class Settings extends Page implements HasSchemas
                         ->required()
                         ->maxLength(191)
                         ->columnSpan(1),
+                ]),
+
+            Group::make()
+                ->columns(4)
+                ->schema([
+                    Select::make('app:locale')
+                        ->label(trans('admin/settings.overview.default-language'))
+                        ->options(function () {
+                            // Helper to get languages since we can't easily access trait method statically or outside instance context in some cases, 
+                            // but here we are in instance context.
+                            return $this->getAvailableLanguages(true);
+                        })
+                        ->searchable()
+                        ->columnSpan(2)
+                        ->native(false),
                 ]),
 
             Group::make()

--- a/app/Http/Middleware/LanguageMiddleware.php
+++ b/app/Http/Middleware/LanguageMiddleware.php
@@ -10,8 +10,10 @@ class LanguageMiddleware
     /**
      * LanguageMiddleware constructor.
      */
-    public function __construct(private Application $app)
-    {
+    public function __construct(
+        private Application $app,
+        private \App\Contracts\Repository\SettingsRepositoryInterface $settings,
+    ) {
     }
 
     /**
@@ -19,7 +21,9 @@ class LanguageMiddleware
      */
     public function handle(Request $request, \Closure $next): mixed
     {
-        $this->app->setLocale($request->user()->language ?? config('app.locale', 'en'));
+        $this->app->setLocale(
+            $request->user()->language ?? $this->settings->get('settings::app:locale', config('app.locale', 'en'))
+        );
 
         return $next($request);
     }

--- a/app/Http/Middleware/LanguageMiddleware.php
+++ b/app/Http/Middleware/LanguageMiddleware.php
@@ -21,9 +21,10 @@ class LanguageMiddleware
      */
     public function handle(Request $request, \Closure $next): mixed
     {
-        $this->app->setLocale(
-            $request->user()->language ?? $this->settings->get('settings::app:locale', config('app.locale', 'en'))
-        );
+        $locale = $request->user()?->language ?? $this->settings->get('settings::app:locale', config('app.locale', 'en'));
+
+        $this->app->setLocale($locale);
+        config(['app.locale' => $locale]);
 
         return $next($request);
     }

--- a/resources/lang/en/admin/settings.php
+++ b/resources/lang/en/admin/settings.php
@@ -12,6 +12,7 @@ return [
         'not-required' => 'Not Required',
         'admin-only' => 'Admin Only',
         'all-users' => 'All Users',
+        'default-language' => 'Default Language',
         'provider' => 'Avatar Provider',
         'enabled' => 'Enabled',
         'disabled' => 'Disabled',

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -14,6 +14,10 @@
 @endsection
 
 @section('content')
+    @php
+        $settings = app(\App\Contracts\Repository\SettingsRepositoryInterface::class);
+        $globalLocale = $settings->get('settings::app:locale', config('app.locale', 'en'));
+    @endphp
     @yield('settings::nav')
     <div class="row">
         <div class="col-xs-12">
@@ -52,7 +56,7 @@
                                 <div>
                                     <select name="app:locale" class="form-control">
                                         @foreach($languages as $key => $value)
-                                            <option value="{{ $key }}" @if(config('app.locale') === $key) selected @endif>{{ $value }}</option>
+                                            <option value="{{ $key }}" @if($globalLocale === $key) selected @endif>{{ $value }}</option>
                                         @endforeach
                                     </select>
                                     <p class="text-muted"><small>The default language to use when rendering the Panel for users who have not selected a custom language.</small></p>

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -47,6 +47,19 @@
                             </div>
                         </div>
                         <div class="row">
+                            <div class="form-group col-md-4">
+                                <label class="control-label">@lang('admin/settings.overview.default-language')</label>
+                                <div>
+                                    <select name="app:locale" class="form-control">
+                                        @foreach($languages as $key => $value)
+                                            <option value="{{ $key }}" @if(config('app.locale') === $key) selected @endif>{{ $value }}</option>
+                                        @endforeach
+                                    </select>
+                                    <p class="text-muted"><small>The default language to use when rendering the Panel for users who have not selected a custom language.</small></p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
                             <div class="form-group col-md-2">
                                 <label class="control-label">@lang('admin/settings.overview.debug-mode')</label>
                                 <div>


### PR DESCRIPTION
This PR adds a new setting to the Admin Panel that lets you choose a default language for everyone. It's perfect for hosting providers who want their panel to start in a specific language (like Spanish or Portuguese) for guests and new users.

**Changes:**

_Admin Settings:_ Added a "Default Language" dropdown to the General tab.
_Middleware:_ Updated the language middleware to respect this new setting if a user hasn't picked their own language.

**How to test:**

1. Go to Admin -> Settings and set a new default language.
2. Open the panel in an Incognito window — the login page should now be in that language!