### PR TITLE
File Manager Image Viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "tailwindcss": "^3.0.24",
         "use-fit-text": "^2.4.0",
         "uuid": "^13.0.0",
+        "viewerjs": "^1.11.7",
         "xterm": "^4.19.0",
         "xterm-addon-fit": "^0.5.0",
         "xterm-addon-search": "^0.9.0",

--- a/resources/scripts/api/server/files/isImageFile.ts
+++ b/resources/scripts/api/server/files/isImageFile.ts
@@ -1,0 +1,22 @@
+import { FileObject } from '@/api/server/files/loadDirectory';
+
+export const isImageFile = (file: FileObject): boolean => {
+    if (!file.isFile) return false;
+
+    // All common image MIME types of viewable Images
+    const imageMimeTypes = [
+        'image/jpeg',
+        'image/jpg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+        'image/bmp',
+        'image/svg+xml',
+        'image/tiff',
+        'image/x-icon',
+        'image/vnd.microsoft.icon',
+    ];
+    
+    return imageMimeTypes.includes(file.mimetype.toLowerCase());
+};
+

--- a/resources/scripts/components/server/files/FileManagerContainer.tsx
+++ b/resources/scripts/components/server/files/FileManagerContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { httpErrorToHuman } from '@/api/http';
 import { CSSTransition } from 'react-transition-group';
 import Spinner from '@/components/elements/Spinner';
@@ -24,6 +24,9 @@ import { hashToPath } from '@/helpers';
 import style from './style.module.css';
 import Card from '@/reviactyl/ui/Card';
 import { useTranslation } from 'react-i18next';
+import ImageViewerModal from '@/components/server/files/ImageViewerModal';
+import getFileDownloadUrl from '@/api/server/files/getFileDownloadUrl';
+import { join } from 'pathe';
 
 const sortFiles = (files: FileObject[]): FileObject[] => {
     const sortedFiles: FileObject[] = files
@@ -35,6 +38,7 @@ const sortFiles = (files: FileObject[]): FileObject[] => {
 export default () => {
     const { t } = useTranslation('server/files');
     const id = ServerContext.useStoreState((state) => state.server.data!.id);
+    const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
     const { hash } = useLocation();
     const { data: files, error, mutate } = useFileManagerSwr();
     const directory = ServerContext.useStoreState((state) => state.files.directory);
@@ -43,6 +47,10 @@ export default () => {
 
     const setSelectedFiles = ServerContext.useStoreActions((actions) => actions.files.setSelectedFiles);
     const selectedFilesLength = ServerContext.useStoreState((state) => state.files.selectedFiles.length);
+
+    // Image viewer state
+    const [imageViewerVisible, setImageViewerVisible] = useState(false);
+    const [selectedImage, setSelectedImage] = useState<{ url: string; name: string } | null>(null);
 
     useEffect(() => {
         clearFlashes('files');
@@ -56,6 +64,23 @@ export default () => {
 
     const onSelectAllClick = (e: React.ChangeEvent<HTMLInputElement>) => {
         setSelectedFiles(e.currentTarget.checked ? files?.map((file) => file.name) || [] : []);
+    };
+
+    const handleImageClick = (file: FileObject) => {
+        const filePath = join(directory, file.name);
+        getFileDownloadUrl(uuid, filePath)
+            .then((url) => {
+                setSelectedImage({ url, name: file.name });
+                setImageViewerVisible(true);
+            })
+            .catch((error) => {
+                console.error('Failed to get image URL:', error);
+            });
+    };
+
+    const handleImageViewerClose = () => {
+        setImageViewerVisible(false);
+        setSelectedImage(null);
     };
 
     if (error) {
@@ -103,13 +128,22 @@ export default () => {
                                     </div>
                                 )}
                                 {sortFiles(files.slice(0, 250)).map((file) => (
-                                    <FileObjectRow key={file.key} file={file} />
+                                    <FileObjectRow key={file.key} file={file} onImageClick={handleImageClick} />
                                 ))}
                                 <MassActionsBar />
                             </div>
                         </CSSTransition>
                     )}
                 </Card>
+            )}
+            {selectedImage && (
+                <ImageViewerModal
+                    visible={imageViewerVisible}
+                    onDismissed={handleImageViewerClose}
+                    imageUrl={selectedImage.url}
+                    imageName={selectedImage.name}
+                    appear
+                />
             )}
         </ServerContentBlock>
     );

--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFileAlt, faFileArchive, faFileImport, faFolder } from '@fortawesome/free-solid-svg-icons';
+import { faFileAlt, faFileArchive, faFileImport, faFolder, faFileImage } from '@fortawesome/free-solid-svg-icons';
 import { encodePathSegments } from '@/helpers';
 import { differenceInHours, format, formatDistanceToNow } from 'date-fns';
 import React, { memo } from 'react';
@@ -14,13 +14,30 @@ import { usePermissions } from '@/plugins/usePermissions';
 import { join } from 'pathe';
 import { bytesToString } from '@/lib/formatters';
 import styles from './style.module.css';
+import { isImageFile } from '@/api/server/files/isImageFile';
 
-const Clickable: React.FC<{ file: FileObject }> = memo(({ file, children }) => {
+const Clickable: React.FC<{ file: FileObject; onImageClick?: () => void }> = memo(({ file, children, onImageClick }) => {
     const [canRead] = usePermissions(['file.read']);
     const [canReadContents] = usePermissions(['file.read-content']);
     const directory = ServerContext.useStoreState((state) => state.files.directory);
 
     const match = useRouteMatch();
+
+    // Handle image files with a click handler instead of navigation
+    if (isImageFile(file) && onImageClick && canReadContents) {
+        return (
+            <div
+                className={styles.details}
+                css={tw`cursor-pointer`}
+                onClick={(e) => {
+                    e.preventDefault();
+                    onImageClick();
+                }}
+            >
+                {children}
+            </div>
+        );
+    }
 
     return (file.isFile && (!file.isEditable() || !canReadContents)) || (!file.isFile && !canRead) ? (
         <div className={styles.details}>{children}</div>
@@ -34,37 +51,53 @@ const Clickable: React.FC<{ file: FileObject }> = memo(({ file, children }) => {
     );
 }, isEqual);
 
-const FileObjectRow = ({ file }: { file: FileObject }) => (
-    <div
-        className={styles.file_row}
-        key={file.name}
-        onContextMenu={(e) => {
-            e.preventDefault();
-            window.dispatchEvent(new CustomEvent(`pterodactyl:files:ctx:${file.key}`, { detail: e.clientX }));
-        }}
-    >
-        <SelectFileCheckbox name={file.name} />
-        <Clickable file={file}>
-            <div css={tw`flex-none text-gray-400 ml-6 mr-4 text-lg pl-3`}>
-                {file.isFile ? (
-                    <FontAwesomeIcon
-                        icon={file.isSymlink ? faFileImport : file.isArchiveType() ? faFileArchive : faFileAlt}
-                    />
-                ) : (
-                    <FontAwesomeIcon icon={faFolder} />
-                )}
-            </div>
-            <div css={tw`flex-1 truncate`}>{file.name}</div>
-            {file.isFile && <div css={tw`w-1/6 text-right mr-4 hidden sm:block`}>{bytesToString(file.size)}</div>}
-            <div css={tw`w-1/5 text-right mr-4 hidden md:block`} title={file.modifiedAt.toString()}>
-                {Math.abs(differenceInHours(file.modifiedAt, new Date())) > 48
-                    ? format(file.modifiedAt, 'MMM do, yyyy h:mma')
-                    : formatDistanceToNow(file.modifiedAt, { addSuffix: true })}
-            </div>
-        </Clickable>
-        <FileDropdownMenu file={file} />
-    </div>
-);
+interface FileObjectRowProps {
+    file: FileObject;
+    onImageClick?: (file: FileObject) => void;
+}
+
+const FileObjectRow = ({ file, onImageClick }: FileObjectRowProps) => {
+    const handleImageClick = onImageClick ? () => onImageClick(file) : undefined;
+    return (
+        <div
+            className={styles.file_row}
+            key={file.name}
+            onContextMenu={(e) => {
+                e.preventDefault();
+                window.dispatchEvent(new CustomEvent(`pterodactyl:files:ctx:${file.key}`, { detail: e.clientX }));
+            }}
+        >
+            <SelectFileCheckbox name={file.name} />
+            <Clickable file={file} onImageClick={handleImageClick}>
+                <div css={tw`flex-none text-gray-400 ml-6 mr-4 text-lg pl-3`}>
+                    {file.isFile ? (
+                        <FontAwesomeIcon
+                            icon={
+                                file.isSymlink
+                                    ? faFileImport
+                                    : file.isArchiveType()
+                                    ? faFileArchive
+                                    : isImageFile(file)
+                                    ? faFileImage
+                                    : faFileAlt
+                            }
+                        />
+                    ) : (
+                        <FontAwesomeIcon icon={faFolder} />
+                    )}
+                </div>
+                <div css={tw`flex-1 truncate`}>{file.name}</div>
+                {file.isFile && <div css={tw`w-1/6 text-right mr-4 hidden sm:block`}>{bytesToString(file.size)}</div>}
+                <div css={tw`w-1/5 text-right mr-4 hidden md:block`} title={file.modifiedAt.toString()}>
+                    {Math.abs(differenceInHours(file.modifiedAt, new Date())) > 48
+                        ? format(file.modifiedAt, 'MMM do, yyyy h:mma')
+                        : formatDistanceToNow(file.modifiedAt, { addSuffix: true })}
+                </div>
+            </Clickable>
+            <FileDropdownMenu file={file} />
+        </div>
+    );
+};
 
 export default memo(FileObjectRow, (prevProps, nextProps) => {
     /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/resources/scripts/components/server/files/ImageViewerModal.tsx
+++ b/resources/scripts/components/server/files/ImageViewerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import Modal, { RequiredModalProps } from '@/components/elements/Modal';
 import Viewer from 'viewerjs';
 import 'viewerjs/dist/viewer.css';

--- a/resources/scripts/components/server/files/ImageViewerModal.tsx
+++ b/resources/scripts/components/server/files/ImageViewerModal.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef } from 'react';
+import Modal, { RequiredModalProps } from '@/components/elements/Modal';
+import Viewer from 'viewerjs';
+import 'viewerjs/dist/viewer.css';
+import tw from 'twin.macro';
+import styled from 'styled-components/macro';
+
+// Quick styled component for the viewer container (might put this into its own file later)
+const ViewerContainer = styled.div`
+    ${tw`flex items-center justify-center bg-gray-900 rounded-lg overflow-hidden`};
+    min-height: 500px;
+    max-height: 80vh;
+    
+    img {
+        ${tw`max-w-full max-h-full object-contain`};
+        display: block;
+        margin: auto;
+    }
+`;
+
+interface Props extends RequiredModalProps {
+    imageUrl: string;
+    imageName: string;
+}
+
+const ImageViewerModal: React.FC<Props> = ({ imageUrl, imageName, ...modalProps }) => {
+    const imageRef = useRef<HTMLImageElement>(null);
+    const viewerRef = useRef<Viewer | null>(null);
+
+    const handleImageClick = () => {
+        if (!imageRef.current || viewerRef.current) return;
+
+        // Create viewer on demand
+        const viewer = new Viewer(imageRef.current, {
+            inline: false,
+            button: true,
+            navbar: false,
+            title: true,
+            toolbar: {
+                zoomIn: 1,
+                zoomOut: 1,
+                oneToOne: 1,
+                reset: 1,
+                rotateLeft: 1,
+                rotateRight: 1,
+                flipHorizontal: 1,
+                flipVertical: 1,
+            },
+            tooltip: true,
+            movable: true,
+            zoomable: true,
+            rotatable: true,
+            scalable: true,
+            transition: true,
+            fullscreen: true,
+            keyboard: true,
+            backdrop: true,
+            loading: true,
+            loop: false,
+            hidden() {
+                // Destroy viewer when it's closed
+                viewer.destroy();
+                viewerRef.current = null;
+            },
+        });
+
+        viewerRef.current = viewer;
+        viewer.show();
+    };
+
+    return (
+        <Modal {...modalProps} dismissable>
+            <div css={tw`bg-gray-800 rounded-lg p-6 max-w-5xl w-full`}>
+                <div css={tw`mb-4`}>
+                    <h2 css={tw`text-xl font-semibold text-gray-100`}>{imageName}</h2>
+                </div>
+                <ViewerContainer>
+                    <img
+                        ref={imageRef}
+                        src={imageUrl}
+                        alt={imageName}
+                        css={tw`cursor-pointer`}
+                        onClick={handleImageClick}
+                        onError={(e) => {
+                            // Welp, time to use hacky fallback
+                            (e.target as HTMLImageElement).src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="200" height="200"%3E%3Ctext x="50%25" y="50%25" text-anchor="middle" fill="%23999" font-size="16"%3EImage failed to load%3C/text%3E%3C/svg%3E';
+                        }}
+                    />
+                </ViewerContainer>
+                <div css={tw`mt-4 text-sm text-gray-400 text-center`}>
+                    Click on the image to zoom, rotate, and use other viewer controls
+                </div>
+            </div>
+        </Modal>
+    );
+    // TODO: Make the string in the div container under the ViewerContainer translatable
+};
+
+export default ImageViewerModal;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10399,6 +10399,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+viewerjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/viewerjs/-/viewerjs-1.11.7.tgz#99c39b86c3f1b6debf446747a1f0e25f8be4db74"
+  integrity sha512-0JuVqOmL5v1jmEAlG5EBDR3XquxY8DWFQbFMprOXgaBB0F7Q/X9xWdEaQc59D8xzwkdUgXEMSSknTpriq95igg==
+
 void-elements@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"


### PR DESCRIPTION
Closes #165.

This PR implements an Image Viewer for the Panel File explorer using ViewerJS.
It should work with pretty much all common image types, but I tested with a PNG only so far.

# Screenshots
## Image Modal
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1379c138-9cc3-48b7-afc4-e1b573dc1ec5" />

## Fullscreen Viewer (ViewerJS, after clicking on Image in Modal)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/42b84e3f-65f3-4846-b2d3-3c36f153d05d" />

