### PR TITLE
Server Kill Button

### DIFF
--- a/app/Http/Requests/Admin/Designify/GeneralSettingsFormRequest.php
+++ b/app/Http/Requests/Admin/Designify/GeneralSettingsFormRequest.php
@@ -19,6 +19,7 @@ class GeneralSettingsFormRequest extends AdminFormRequest
             'designify:statusCardLink' => 'nullable|string|max:255',
             'designify:supportCardLink' => 'nullable|string|max:255',
             'designify:billingCardLink' => 'nullable|string|max:255',
+            'designify:alwaysShowKillButton' => 'required|in:true,false',
         ];
     }
 

--- a/app/Http/ViewComposers/DesignifyComposer.php
+++ b/app/Http/ViewComposers/DesignifyComposer.php
@@ -167,6 +167,7 @@ class DesignifyComposer
             'statusCardLink' => config('designify.statusCardLink') ?? '',
             'supportCardLink' => config('designify.supportCardLink') ?? '',
             'billingCardLink' => config('designify.billingCardLink') ?? '',
+            'alwaysShowKillButton' => config('designify.alwaysShowKillButton', false),
         ];
     }
 

--- a/app/Providers/DesignifyServiceProvider.php
+++ b/app/Providers/DesignifyServiceProvider.php
@@ -51,6 +51,7 @@ class DesignifyServiceProvider extends ServiceProvider
         "designify:statusCardLink",
         "designify:supportCardLink",
         "designify:billingCardLink",
+        "designify:alwaysShowKillButton",
         "designify:theme1:name",
         "designify:theme1:colorPrimary",
         "designify:theme1:color50",

--- a/config/designify.php
+++ b/config/designify.php
@@ -43,6 +43,8 @@ return [
     'supportCardLink' => '',
     'billingCardLink' => '',
 
+    'alwaysShowKillButton' => false,
+
     'theme1' => [
         'name' => 'Petrascia',
         'colorPrimary' => '#3b82f6',

--- a/resources/scripts/components/server/console/PowerButtons.tsx
+++ b/resources/scripts/components/server/console/PowerButtons.tsx
@@ -5,6 +5,8 @@ import { ServerContext } from '@/state/server';
 import { PowerAction } from '@/components/server/console/ServerConsoleContainer';
 import { Dialog } from '@/components/elements/dialog';
 import { useTranslation } from 'react-i18next';
+import { useStoreState } from 'easy-peasy';
+import { ApplicationStore } from '@/state';
 
 interface PowerButtonProps {
     className?: string;
@@ -15,6 +17,7 @@ export default ({ className }: PowerButtonProps) => {
     const [open, setOpen] = useState(false);
     const status = ServerContext.useStoreState((state) => state.status.value);
     const instance = ServerContext.useStoreState((state) => state.socket.instance);
+    const alwaysShowKillButton = useStoreState((state: ApplicationStore) => state.reviactyl.data?.alwaysShowKillButton);
 
     const killable = status === 'stopping';
     const onButtonClick = (
@@ -51,27 +54,42 @@ export default ({ className }: PowerButtonProps) => {
                 {t('kill-warning')}
             </Dialog.Confirm>
             <Can action={'control.start'}>
+                {(!alwaysShowKillButton || status === 'offline') && (
                 <Button.Success
                     className={'flex-1'}
-                    disabled={status !== 'offline'}
                     onClick={onButtonClick.bind(this, 'start')}
                 >
                     {t('start')}
                 </Button.Success>
+                )}
             </Can>
             <Can action={'control.restart'}>
-                <Button.Text className={'flex-1'} disabled={!status} onClick={onButtonClick.bind(this, 'restart')}>
+                {(!alwaysShowKillButton || status !== 'offline') && (
+                <Button.Text 
+                    className={'flex-1'}
+                    disabled={!status}
+                    onClick={onButtonClick.bind(this, 'restart')}>
                     {t('restart')}
                 </Button.Text>
+                )}
             </Can>
             <Can action={'control.stop'}>
                 <Button.Danger
                     className={'flex-1'}
                     disabled={status === 'offline'}
-                    onClick={onButtonClick.bind(this, killable ? 'kill' : 'stop')}
+                    onClick={onButtonClick.bind(this, !alwaysShowKillButton && killable ? 'kill' : 'stop')}
                 >
-                    {killable ? t('kill') : t('stop')}
+                    {!alwaysShowKillButton && killable ? t('kill') : t('stop')}
                 </Button.Danger>
+                {alwaysShowKillButton && (
+                <Button.Danger
+                    className={'flex-1'}
+                    disabled={status === 'offline'}
+                    onClick={onButtonClick.bind(this, 'kill')}
+                >
+                    {t('kill')}
+                </Button.Danger>
+                )}
             </Can>
         </div>
     );

--- a/resources/scripts/state/reviactyl.ts
+++ b/resources/scripts/state/reviactyl.ts
@@ -13,6 +13,7 @@ export interface ReviactylSettings {
     statusCardLink: string;
     supportCardLink: string;
     billingCardLink: string;
+    alwaysShowKillButton: boolean;
 }
 
 export interface ReviactylSettingsStore {

--- a/resources/views/admin/designify/general.blade.php
+++ b/resources/views/admin/designify/general.blade.php
@@ -56,6 +56,24 @@
             </div>
             <div class="space-y-3">
                 <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                    for="designify:alwaysShowKillButton">
+                    Always Show Kill Button
+                </label>
+                <select name="designify:alwaysShowKillButton" id="designify:alwaysShowKillButton"
+                    class="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200">
+                    <option value="true"
+                        {{ old('designify:alwaysShowKillButton', config('designify.alwaysShowKillButton')) === true ? 'selected' : '' }}>
+                        Enabled
+                    </option>
+                    <option value="false"
+                        {{ old('designify:alwaysShowKillButton', config('designify.alwaysShowKillButton')) === false ? 'selected' : '' }}>
+                        Disabled
+                    </option>
+                </select>
+                <p class="text-xs text-zinc-500">If enabled, the kill button will always be shown on the server control page, even if the server is offline.</p>
+            </div>
+            <div class="space-y-3">
+                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300"
                     for="designify:statusCardLink">
                     Status Card Link
                 </label>


### PR DESCRIPTION
Fixes #167.

This PR adds an option to Designify: If the Server Kill Option should always be visible.

- By default, the Kill Button is hidden behind "Stop".
- With this enabled, the "Restart" Button is hidden behind the "Start" button instead, leaving space for the "Kill" Button to always be visible. 

Honestly, this should've been in Pterodactyl in the first place.

Merging after checks complete.

# Screenshots
## Option Enabled
<img width="282" height="88" alt="image" src="https://github.com/user-attachments/assets/30689355-a26a-41af-97a3-ea60447811a8" />

## Option Disabled
<img width="275" height="71" alt="image" src="https://github.com/user-attachments/assets/7c38b32c-0915-4a32-9302-5f4ddd3fe446" />
