### PR TITLE
Last Seen Statistic in User Table

### DIFF
--- a/app/Filament/Resources/Users/Tables/UsersTable.php
+++ b/app/Filament/Resources/Users/Tables/UsersTable.php
@@ -38,6 +38,10 @@ class UsersTable
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable(),
+                TextColumn::make('last_seen')
+                    ->sortable()
+                    ->formatStateUsing(fn ($record) => $record->last_seen?->diffForHumans())
+                    ->placeholder(trans('generic.never')),
             ])
             ->filters([
                 \Filament\Tables\Filters\TernaryFilter::make('root_admin')

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,6 +15,7 @@ use App\Http\Middleware\VerifyCaptcha;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 use App\Http\Middleware\LanguageMiddleware;
 use App\Http\Middleware\EditorMiddleware;
+use App\Http\Middleware\UpdateLastSeen;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use App\Http\Middleware\Activity\TrackAPIKey;
@@ -66,6 +67,7 @@ class Kernel extends HttpKernel
             SubstituteBindings::class,
             LanguageMiddleware::class,
             EditorMiddleware::class,
+            UpdateLastSeen::class,
         ],
         'api' => [
             EnsureStatefulRequests::class,

--- a/app/Http/Middleware/UpdateLastSeen.php
+++ b/app/Http/Middleware/UpdateLastSeen.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateLastSeen
+{
+    /**
+     * Handle an incoming request and update the user's last_seen timestamp.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (Auth::check()) {
+            $user = Auth::user();
+            
+            // Only update if last_seen is null or was updated more than 5 minutes ago (to prevent excessive database writes)
+            if (
+                is_null($user->last_seen) ||
+                $user->last_seen->lt(now()->subMinutes(5))
+            ) {
+                $user->update(['last_seen' => now()]);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -145,6 +145,7 @@ class User extends Model implements
         'gravatar',
         'root_admin',
         'editor',
+        'last_seen',
     ];
 
     /**
@@ -156,6 +157,7 @@ class User extends Model implements
         'gravatar' => 'boolean',
         'totp_authenticated_at' => 'datetime',
         'editor' => 'string',
+        'last_seen' => 'datetime',
     ];
 
     /**

--- a/database/migrations/2026_02_12_182802_add_last_seen_to_users_table.php
+++ b/database/migrations/2026_02_12_182802_add_last_seen_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('last_seen')->nullable()->after('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('last_seen');
+        });
+    }
+};

--- a/resources/lang/en/generic.php
+++ b/resources/lang/en/generic.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'never' => 'Never',
+];


### PR DESCRIPTION
Closes #163.

Adds a new field to the users table (See new Migration in first commit) that tracks the last time the panel was accessed by the user.
[This has a cooldown of 5 minutes so the Database isn't excessively written to.]

Also added generic.php for Strings that are Generic and can be used by multiple different things at the same time.