### PR TITLE
feat(designify): add customizable error pages for 403, 404, and 500 #168

### DIFF
--- a/app/Http/Controllers/Admin/Designify/ErrorPagesController.php
+++ b/app/Http/Controllers/Admin/Designify/ErrorPagesController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Designify;
+
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+use Prologue\Alerts\AlertsMessageBag;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\View\Factory as ViewFactory;
+use App\Http\Controllers\Controller;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use App\Contracts\Repository\SettingsRepositoryInterface;
+use App\Http\Requests\Admin\Designify\ErrorPagesSettingsFormRequest;
+
+class ErrorPagesController extends Controller
+{
+    /**
+     * ErrorPagesController constructor.
+     */
+    public function __construct(
+        private AlertsMessageBag $alert,
+        private ConfigRepository $config,
+        private Kernel $kernel,
+        private SettingsRepositoryInterface $settings,
+        private ViewFactory $view,
+    ) {
+    }
+
+    /**
+     * Render Error Pages settings UI.
+     */
+    public function index(): View
+    {
+        return $this->view->make('admin.designify.errors');
+    }
+
+    /**
+     * Update error page settings.
+     */
+    public function update(ErrorPagesSettingsFormRequest $request): RedirectResponse
+    {
+        foreach ($request->normalize() as $key => $value) {
+            $this->settings->set('settings::' . $key, $value);
+        }
+
+        $this->kernel->call('queue:restart');
+        $this->alert->success('Error page settings have been updated successfully.')->flash();
+
+        return redirect()->route('admin.designify.errors');
+    }
+}

--- a/app/Http/Controllers/Admin/Designify/ErrorPagesController.php
+++ b/app/Http/Controllers/Admin/Designify/ErrorPagesController.php
@@ -48,4 +48,24 @@ class ErrorPagesController extends Controller
 
         return redirect()->route('admin.designify.errors');
     }
+
+    /**
+     * Preview a specific error page.
+     */
+    public function preview(\Illuminate\Http\Request $request, int $code): View
+    {
+        if (!in_array($code, [403, 404, 500])) {
+            abort(404);
+        }
+
+        // Override config values if data is provided in the request (Live Preview)
+        foreach ($request->all() as $key => $value) {
+            if (str_starts_with($key, 'designify:errors:' . $code . ':')) {
+                $configKey = str_replace(':', '.', str_replace('designify:', 'designify.', $key));
+                $this->config->set($configKey, $value);
+            }
+        }
+
+        return $this->view->make('errors.' . $code);
+    }
 }

--- a/app/Http/Requests/Admin/Designify/ErrorPagesSettingsFormRequest.php
+++ b/app/Http/Requests/Admin/Designify/ErrorPagesSettingsFormRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests\Admin\Designify;
+
+use App\Http\Requests\Admin\AdminFormRequest;
+
+class ErrorPagesSettingsFormRequest extends AdminFormRequest
+{
+    /**
+     * Return all the rules to apply to this request's data.
+     */
+    public function rules(): array
+    {
+        return [
+            'designify:errors:403:title' => 'present|nullable|string|max:191',
+            'designify:errors:403:message' => 'present|nullable|string',
+            'designify:errors:403:button' => 'present|nullable|string|max:191',
+            'designify:errors:403:image' => 'present|nullable|string|max:191',
+            'designify:errors:403:color' => 'present|nullable|string|max:191',
+            
+            'designify:errors:404:title' => 'present|nullable|string|max:191',
+            'designify:errors:404:message' => 'present|nullable|string',
+            'designify:errors:404:button' => 'present|nullable|string|max:191',
+            'designify:errors:404:image' => 'present|nullable|string|max:191',
+            'designify:errors:404:color' => 'present|nullable|string|max:191',
+            
+            'designify:errors:500:title' => 'present|nullable|string|max:191',
+            'designify:errors:500:message' => 'present|nullable|string',
+            'designify:errors:500:button' => 'present|nullable|string|max:191',
+            'designify:errors:500:image' => 'present|nullable|string|max:191',
+            'designify:errors:500:color' => 'present|nullable|string|max:191',
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'designify:errors:403:title' => '403 Title',
+            'designify:errors:403:message' => '403 Message',
+            'designify:errors:403:button' => '403 Button Text',
+            'designify:errors:403:image' => '403 Image URL',
+            'designify:errors:403:color' => '403 Accent Color',
+            
+            'designify:errors:404:title' => '404 Title',
+            'designify:errors:404:message' => '404 Message',
+            'designify:errors:404:button' => '404 Button Text',
+            'designify:errors:404:image' => '404 Image URL',
+            'designify:errors:404:color' => '404 Accent Color',
+            
+            'designify:errors:500:title' => '500 Title',
+            'designify:errors:500:message' => '500 Message',
+            'designify:errors:500:button' => '500 Button Text',
+            'designify:errors:500:image' => '500 Image URL',
+            'designify:errors:500:color' => '500 Accent Color',
+        ];
+    }
+}

--- a/app/Providers/DesignifyServiceProvider.php
+++ b/app/Providers/DesignifyServiceProvider.php
@@ -135,6 +135,21 @@ class DesignifyServiceProvider extends ServiceProvider
         "designify:theme7:color700",
         "designify:theme7:color800",
         "designify:theme7:color900",
+        "designify:errors:403:title",
+        "designify:errors:403:message",
+        "designify:errors:403:button",
+        "designify:errors:403:image",
+        "designify:errors:403:color",
+        "designify:errors:404:title",
+        "designify:errors:404:message",
+        "designify:errors:404:button",
+        "designify:errors:404:image",
+        "designify:errors:404:color",
+        "designify:errors:500:title",
+        "designify:errors:500:message",
+        "designify:errors:500:button",
+        "designify:errors:500:image",
+        "designify:errors:500:color",
     ];
 
     /**

--- a/resources/views/admin/designify/errors.blade.php
+++ b/resources/views/admin/designify/errors.blade.php
@@ -1,0 +1,108 @@
+@extends('layouts.designify', ['sideEditor' => true])
+
+@section('title')
+    Error Page Settings
+@endsection
+
+@section('content')
+    <form id="designifyEditor" action="" method="POST" class="h-full flex flex-col">
+        @csrf
+        @method('PATCH')
+        <div class="mb-8">
+            <h1 class="text-2xl font-bold text-white mb-2">Error Page Customization</h1>
+            <p class="text-zinc-400 text-sm">Customize titles, messages, images, and colors for HTTP error pages.</p>
+        </div>
+
+        <div class="flex-1 space-y-12 pb-20">
+            <!-- 403 Forbidden -->
+            <div class="space-y-6">
+                <div class="flex items-center space-x-3 border-b border-zinc-800 pb-3">
+                    <span class="px-2 py-1 bg-amber-500/10 text-amber-500 rounded text-xs font-bold">403</span>
+                    <h2 class="text-lg font-semibold text-white">Forbidden</h2>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Title</label>
+                        <input type="text" name="designify:errors:403:title" value="{{ old('designify:errors:403:title', config('designify.errors.403.title')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="Forbidden">
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Button Text</label>
+                        <input type="text" name="designify:errors:403:button" value="{{ old('designify:errors:403:button', config('designify.errors.403.button')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="Go to Dashboard">
+                    </div>
+                    <div class="col-span-full space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Message</label>
+                        <textarea name="designify:errors:403:message" rows="3" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="You do not have permission to access this resource.">{{ old('designify:errors:403:message', config('designify.errors.403.message')) }}</textarea>
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Image URL</label>
+                        <input type="text" name="designify:errors:403:image" value="{{ old('designify:errors:403:image', config('designify.errors.403.image')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="https://example.com/forbidden.svg">
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Accent Color</label>
+                        <input type="text" name="designify:errors:403:color" value="{{ old('designify:errors:403:color', config('designify.errors.403.color')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="#f59e0b">
+                    </div>
+                </div>
+            </div>
+
+            <!-- 404 Not Found -->
+            <div class="space-y-6">
+                <div class="flex items-center space-x-3 border-b border-zinc-800 pb-3">
+                    <span class="px-2 py-1 bg-blue-500/10 text-blue-500 rounded text-xs font-bold">404</span>
+                    <h2 class="text-lg font-semibold text-white">Not Found</h2>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Title</label>
+                        <input type="text" name="designify:errors:404:title" value="{{ old('designify:errors:404:title', config('designify.errors.404.title')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="Page Not Found">
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Button Text</label>
+                        <input type="text" name="designify:errors:404:button" value="{{ old('designify:errors:404:button', config('designify.errors.404.button')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="Go Home">
+                    </div>
+                    <div class="col-span-full space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Message</label>
+                        <textarea name="designify:errors:404:message" rows="3" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="The page you are looking for does not exist.">{{ old('designify:errors:404:message', config('designify.errors.404.message')) }}</textarea>
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Image URL</label>
+                        <input type="text" name="designify:errors:404:image" value="{{ old('designify:errors:404:image', config('designify.errors.404.image')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="https://example.com/notfound.svg">
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Accent Color</label>
+                        <input type="text" name="designify:errors:404:color" value="{{ old('designify:errors:404:color', config('designify.errors.404.color')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="#3b82f6">
+                    </div>
+                </div>
+            </div>
+
+            <!-- 500 Server Error -->
+            <div class="space-y-6">
+                <div class="flex items-center space-x-3 border-b border-zinc-800 pb-3">
+                    <span class="px-2 py-1 bg-red-500/10 text-red-500 rounded text-xs font-bold">500</span>
+                    <h2 class="text-lg font-semibold text-white">Server Error</h2>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Title</label>
+                        <input type="text" name="designify:errors:500:title" value="{{ old('designify:errors:500:title', config('designify.errors.500.title')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="Internal Server Error">
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Button Text</label>
+                        <input type="text" name="designify:errors:500:button" value="{{ old('designify:errors:500:button', config('designify.errors.500.button')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="Try Again">
+                    </div>
+                    <div class="col-span-full space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Message</label>
+                        <textarea name="designify:errors:500:message" rows="3" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="Something went wrong on our end. Please try again later.">{{ old('designify:errors:500:message', config('designify.errors.500.message')) }}</textarea>
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Image URL</label>
+                        <input type="text" name="designify:errors:500:image" value="{{ old('designify:errors:500:image', config('designify.errors.500.image')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="https://example.com/server_error.svg">
+                    </div>
+                    <div class="space-y-2">
+                        <label class="block text-sm font-medium text-zinc-400">Accent Color</label>
+                        <input type="text" name="designify:errors:500:color" value="{{ old('designify:errors:500:color', config('designify.errors.500.color')) }}" class="w-full px-4 py-2 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white focus:ring-2 focus:ring-blue-500 outline-none transition-all" placeholder="#ef4444">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+@endsection

--- a/resources/views/admin/designify/errors.blade.php
+++ b/resources/views/admin/designify/errors.blade.php
@@ -19,6 +19,7 @@
                 <div class="flex items-center space-x-3 border-b border-zinc-800 pb-3">
                     <span class="px-2 py-1 bg-amber-500/10 text-amber-500 rounded text-xs font-bold">403</span>
                     <h2 class="text-lg font-semibold text-white">Forbidden</h2>
+                    <button type="button" onclick="changePreview('{{ route('admin.designify.errors.preview', 403) }}')" class="ml-auto text-xs font-medium text-zinc-500 hover:text-white transition-colors bg-zinc-800/50 px-2 py-1 rounded-md border border-zinc-700">Preview 403</button>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="space-y-2">
@@ -49,6 +50,7 @@
                 <div class="flex items-center space-x-3 border-b border-zinc-800 pb-3">
                     <span class="px-2 py-1 bg-blue-500/10 text-blue-500 rounded text-xs font-bold">404</span>
                     <h2 class="text-lg font-semibold text-white">Not Found</h2>
+                    <button type="button" onclick="changePreview('{{ route('admin.designify.errors.preview', 404) }}')" class="ml-auto text-xs font-medium text-zinc-500 hover:text-white transition-colors bg-zinc-800/50 px-2 py-1 rounded-md border border-zinc-700">Preview 404</button>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="space-y-2">
@@ -79,6 +81,7 @@
                 <div class="flex items-center space-x-3 border-b border-zinc-800 pb-3">
                     <span class="px-2 py-1 bg-red-500/10 text-red-500 rounded text-xs font-bold">500</span>
                     <h2 class="text-lg font-semibold text-white">Server Error</h2>
+                    <button type="button" onclick="changePreview('{{ route('admin.designify.errors.preview', 500) }}')" class="ml-auto text-xs font-medium text-zinc-500 hover:text-white transition-colors bg-zinc-800/50 px-2 py-1 rounded-md border border-zinc-700">Preview 500</button>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div class="space-y-2">
@@ -105,4 +108,30 @@
             </div>
         </div>
     </form>
+
+    <script>
+        // Debounce function to limit preview requests
+        function debounce(func, wait) {
+            let timeout;
+            return function executedFunction(...args) {
+                const later = () => {
+                    clearTimeout(timeout);
+                    func(...args);
+                };
+                clearTimeout(timeout);
+                timeout = setTimeout(later, wait);
+            };
+        }
+
+        // Auto-refresh preview when inputs change
+        const autoRefresh = debounce(() => {
+            if (typeof refreshPreview === 'function') {
+                refreshPreview();
+            }
+        }, 500);
+
+        document.getElementById('designifyEditor').querySelectorAll('input, textarea').forEach(input => {
+            input.addEventListener('input', autoRefresh);
+        });
+    </script>
 @endsection

--- a/resources/views/components/designify/preview.blade.php
+++ b/resources/views/components/designify/preview.blade.php
@@ -1,8 +1,18 @@
 <main class="flex-1 flex flex-col">
    <div class="flex items-center justify-between p-2 bg-zinc-800 rounded-lg rounded-b-none border border-zinc-700">
-      <span class="text-base text-white/50 bg-zinc-900 px-5 rounded-lg">
-      Preview
-      </span>
+      <div class="flex items-center space-x-2">
+         <span class="text-base text-white/50 bg-zinc-900 px-5 rounded-lg mr-2">
+         Preview
+         </span>
+         @if(Route::currentRouteName() === 'admin.designify.errors')
+            <div class="flex items-center space-x-1 bg-zinc-900 p-1 rounded-lg border border-zinc-700">
+               <button onclick="changePreview('/')" class="error-preview-btn active px-3 py-1 rounded-md text-xs font-bold text-white/50 hover:text-white transition-all" data-code="default">Dashboard</button>
+               <button onclick="changePreview('{{ route('admin.designify.errors.preview', 403) }}')" class="error-preview-btn px-3 py-1 rounded-md text-xs font-bold text-white/50 hover:text-white transition-all" data-code="403">403</button>
+               <button onclick="changePreview('{{ route('admin.designify.errors.preview', 404) }}')" class="error-preview-btn px-3 py-1 rounded-md text-xs font-bold text-white/50 hover:text-white transition-all" data-code="404">404</button>
+               <button onclick="changePreview('{{ route('admin.designify.errors.preview', 500) }}')" class="error-preview-btn px-3 py-1 rounded-md text-xs font-bold text-white/50 hover:text-white transition-all" data-code="500">500</button>
+            </div>
+         @endif
+      </div>
       <div class="flex items-center space-x-1 bg-zinc-800 p-1 rounded-lg border border-zinc-700">
          <button id="preview-desktop" class="preview-btn active p-2 rounded-md text-white/50">
             <x-heroicon-m-computer-desktop class="h-4 w-4"/>
@@ -14,7 +24,63 @@
    </div>
    <div class="flex-1 flex items-center justify-center bg-zinc-800 border border-zinc-700 rounded-lg rounded-t-none">
       <div id="preview-container" class="transition-all duration-300 w-full h-full">
-         <iframe src="/" class="w-full h-full shadow-2xl bg-white"></iframe>
+         <iframe id="designify-preview-iframe" name="designify-preview-iframe" src="/" class="w-full h-full shadow-2xl bg-white"></iframe>
       </div>
    </div>
 </main>
+
+<script>
+   let lastPreviewUrl = '/';
+   
+   function changePreview(url) {
+      const iframe = document.getElementById('designify-preview-iframe');
+      const form = document.getElementById('designifyEditor');
+      
+      if (iframe) {
+         lastPreviewUrl = url;
+         
+         if (form && url !== '/') {
+            // Live preview: submit form to iframe
+            const originalAction = form.action;
+            const originalTarget = form.target;
+            const originalMethod = form.method;
+            
+            // Temporary change action and target
+            form.action = url;
+            form.target = 'designify-preview-iframe';
+            form.method = 'POST';
+            
+            form.submit();
+            
+            // Restore form attributes
+            form.action = originalAction;
+            form.target = originalTarget;
+            form.method = originalMethod;
+         } else {
+            iframe.src = url;
+         }
+         
+         // Update active state of buttons
+         document.querySelectorAll('.error-preview-btn').forEach(btn => {
+            btn.classList.remove('active', 'bg-zinc-800', 'text-white');
+            btn.classList.add('text-white/50');
+            
+            if (btn.getAttribute('onclick').includes(url)) {
+               btn.classList.add('active', 'bg-zinc-800', 'text-white');
+               btn.classList.remove('text-white/50');
+            }
+            if (url === '/' && btn.dataset.code === 'default') {
+               btn.classList.add('active', 'bg-zinc-800', 'text-white');
+               btn.classList.remove('text-white/50');
+            }
+         });
+      }
+   }
+
+   // Function to refresh current preview with latest form data
+   function refreshPreview() {
+      if (lastPreviewUrl && lastPreviewUrl !== '/') {
+         changePreview(lastPreviewUrl);
+      }
+   }
+</script>

--- a/resources/views/components/designify/sidebar.blade.php
+++ b/resources/views/components/designify/sidebar.blade.php
@@ -25,6 +25,11 @@
          icon="fa-solid fa-gear"
          label="Site Meta Settings"
          :active="str_starts_with(Route::currentRouteName(),'admin.designify.site')" />
+      <x-designify.tab-button
+         :route="route('admin.designify.errors')"
+         icon="fa-solid fa-triangle-exclamation"
+         label="Error Pages"
+         :active="str_starts_with(Route::currentRouteName(),'admin.designify.errors')" />
       @include('partials.admin.designify.save')
    </div>
    <div class="flex-1 overflow-y-auto mt-2 pr-1 text-white p-1">

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ config('designify.errors.403.title') ?? '403 - Forbidden' }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .accent-color { color: {{ config('designify.errors.403.color') ?? '#f59e0b' }}; }
+        .accent-bg { background-color: {{ config('designify.errors.403.color') ?? '#f59e0b' }}; }
+        .accent-ring { --tw-ring-color: {{ config('designify.errors.403.color') ?? '#f59e0b' }}; }
+    </style>
+</head>
+<body class="bg-[#0b0f17] text-white min-h-screen flex items-center justify-center p-6">
+    <div class="max-w-2xl w-full text-center space-y-8">
+        @if(config('designify.errors.403.image'))
+            <img src="{{ config('designify.errors.403.image') }}" alt="403" class="mx-auto max-h-64 object-contain mb-8">
+        @else
+            <div class="text-9xl font-bold opacity-10 absolute inset-0 flex items-center justify-center pointer-events-none select-none">403</div>
+        @endif
+
+        <div class="relative z-10 space-y-4">
+            <h1 class="text-4xl md:text-5xl font-bold tracking-tight">
+                {{ config('designify.errors.403.title') ?? 'Access Forbidden' }}
+            </h1>
+            <p class="text-zinc-400 text-lg md:text-xl max-w-md mx-auto">
+                {{ config('designify.errors.403.message') ?? 'You do not have permission to access this resource. Please contact the administrator if you believe this is an error.' }}
+            </p>
+        </div>
+
+        <div class="pt-4">
+            <a href="/" class="inline-flex items-center px-8 py-3 rounded-xl font-semibold text-white accent-bg hover:opacity-90 transition-all focus:ring-4 accent-ring outline-none">
+                {{ config('designify.errors.403.button') ?? 'Back to Dashboard' }}
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ config('designify.errors.404.title') ?? '404 - Page Not Found' }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .accent-color { color: {{ config('designify.errors.404.color') ?? '#3b82f6' }}; }
+        .accent-bg { background-color: {{ config('designify.errors.404.color') ?? '#3b82f6' }}; }
+        .accent-ring { --tw-ring-color: {{ config('designify.errors.404.color') ?? '#3b82f6' }}; }
+    </style>
+</head>
+<body class="bg-[#0b0f17] text-white min-h-screen flex items-center justify-center p-6">
+    <div class="max-w-2xl w-full text-center space-y-8">
+        @if(config('designify.errors.404.image'))
+            <img src="{{ config('designify.errors.404.image') }}" alt="404" class="mx-auto max-h-64 object-contain mb-8">
+        @else
+            <div class="text-9xl font-bold opacity-10 absolute inset-0 flex items-center justify-center pointer-events-none select-none">404</div>
+        @endif
+
+        <div class="relative z-10 space-y-4">
+            <h1 class="text-4xl md:text-5xl font-bold tracking-tight">
+                {{ config('designify.errors.404.title') ?? 'Page Not Found' }}
+            </h1>
+            <p class="text-zinc-400 text-lg md:text-xl max-w-md mx-auto">
+                {{ config('designify.errors.404.message') ?? 'The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.' }}
+            </p>
+        </div>
+
+        <div class="pt-4">
+            <a href="/" class="inline-flex items-center px-8 py-3 rounded-xl font-semibold text-white accent-bg hover:opacity-90 transition-all focus:ring-4 accent-ring outline-none">
+                {{ config('designify.errors.404.button') ?? 'Back to Dashboard' }}
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ config('designify.errors.500.title') ?? '500 - Server Error' }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        .accent-color { color: {{ config('designify.errors.500.color') ?? '#ef4444' }}; }
+        .accent-bg { background-color: {{ config('designify.errors.500.color') ?? '#ef4444' }}; }
+        .accent-ring { --tw-ring-color: {{ config('designify.errors.500.color') ?? '#ef4444' }}; }
+    </style>
+</head>
+<body class="bg-[#0b0f17] text-white min-h-screen flex items-center justify-center p-6">
+    <div class="max-w-2xl w-full text-center space-y-8">
+        @if(config('designify.errors.500.image'))
+            <img src="{{ config('designify.errors.500.image') }}" alt="500" class="mx-auto max-h-64 object-contain mb-8">
+        @else
+            <div class="text-9xl font-bold opacity-10 absolute inset-0 flex items-center justify-center pointer-events-none select-none">500</div>
+        @endif
+
+        <div class="relative z-10 space-y-4">
+            <h1 class="text-4xl md:text-5xl font-bold tracking-tight">
+                {{ config('designify.errors.500.title') ?? 'Internal Server Error' }}
+            </h1>
+            <p class="text-zinc-400 text-lg md:text-xl max-w-md mx-auto">
+                {{ config('designify.errors.500.message') ?? 'We encountered an error while processing your request. Please try again later or contact support if the problem persists.' }}
+            </p>
+        </div>
+
+        <div class="pt-4">
+            <a href="/" class="inline-flex items-center px-8 py-3 rounded-xl font-semibold text-white accent-bg hover:opacity-90 transition-all focus:ring-4 accent-ring outline-none">
+                {{ config('designify.errors.500.button') ?? 'Try Again' }}
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -261,4 +261,5 @@ Route::group(['prefix' => 'designify'], function () {
     Route::patch('/site', [Admin\Designify\SiteController::class, 'update']);
     Route::get('/errors', [Admin\Designify\ErrorPagesController::class, 'index'])->name('admin.designify.errors');
     Route::patch('/errors', [Admin\Designify\ErrorPagesController::class, 'update']);
+    Route::match(['get', 'post', 'patch'], '/errors/preview/{code}', [Admin\Designify\ErrorPagesController::class, 'preview'])->name('admin.designify.errors.preview');
 });

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -259,4 +259,6 @@ Route::group(['prefix' => 'designify'], function () {
 
     Route::get('/site', [Admin\Designify\SiteController::class, 'index'])->name('admin.designify.site');
     Route::patch('/site', [Admin\Designify\SiteController::class, 'update']);
+    Route::get('/errors', [Admin\Designify\ErrorPagesController::class, 'index'])->name('admin.designify.errors');
+    Route::patch('/errors', [Admin\Designify\ErrorPagesController::class, 'update']);
 });


### PR DESCRIPTION
- Designify Integration: Added a new "Error Pages" tab to the Designify settings dashboard.
- Dynamic Content: Customize Titles, Messages, and button text for each error status.
- Visual Branding: Support for custom Illustration/Image URLs and accent colours (buttons/highlights).
- Premium Design: Modern, high-performance dark-themed error templates with responsive layouts and smooth fallbacks.
- Persistence: Settings are persisted via the Designify configuration layer and cached for performance.