### PR TITLE
Support for the development Environment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
                   'process.platform': null,
                   'process.version': null,
                   'process.versions': null,
+                  global: 'globalThis',
               }
             : undefined,
 
@@ -51,6 +52,21 @@ export default defineConfig({
                 'server',
                 'features',
             ),
+        },
+    },
+
+    server: {
+        host: '0.0.0.0',
+        port: 5173,
+        strictPort: true,
+        origin: 'https://reviactyl.test',
+        hmr: {
+            host: 'reviactyl.test',
+            protocol: 'wss',
+            clientPort: 443,
+        },
+        watch: {
+            usePolling: true,
         },
     },
 


### PR DESCRIPTION
Currently, when setting up everything in reviactyl/development, you can get as far as going to the website before being blocked by Routing errors, I have made a Vite config change here that fixes this behaviour, though be aware that I am rusty in Vite and have not tested if this breaks anything.

If you do find issues with this or would like to make changes, refer to Branch "support/dev-environment".