### PR TITLE
feat: Add monitoring page and related widgets for system monitoring

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -10,6 +10,16 @@ class Dashboard extends BaseDashboard
 
     protected static string|\BackedEnum|null $activeNavigationIcon = 'heroicon-s-squares-2x2';
 
+    public function getWidgets(): array
+    {
+        return [
+            \App\Filament\Widgets\UpdateWidget::class,
+            \App\Filament\Widgets\FeedbackWidget::class,
+            \App\Filament\Widgets\SponsorWidget::class,
+            \App\Filament\Widgets\UserActivityWidget::class,
+        ];
+    }
+
     public function getHeading(): string
     {
         return trans('admin/index.title');

--- a/app/Filament/Pages/Monitoring.php
+++ b/app/Filament/Pages/Monitoring.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\Node;
+use App\Repositories\Wings\DaemonMonitoringRepository;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Placeholder;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Section;
+use Illuminate\Support\HtmlString;
+use Livewire\Attributes\On;
+
+class Monitoring extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-chart-bar';
+    protected static string|\BackedEnum|null $activeNavigationIcon = 'heroicon-s-chart-bar';
+    protected static ?int $navigationSort = 3;
+
+    public ?int $selectedNodeId = null;
+
+    public function mount(): void
+    {
+    }
+
+    #[On('nodeChanged')]
+    public function updateSelectedNode(?int $nodeId = null): void
+    {
+        if ($nodeId) {
+            $this->selectedNodeId = $nodeId;
+        }
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return trans('admin/monitoring.navigation.label');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return trans('admin/monitoring.navigation.group');
+    }
+
+    public function getTitle(): string
+    {
+        return trans('admin/monitoring.page.title');
+    }
+
+    public function getHeading(): string
+    {
+        return trans('admin/monitoring.page.heading');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('viewDetails')
+                ->label(trans('admin/monitoring.details.button'))
+                ->icon('heroicon-o-chart-bar-square')
+                ->color('gray')
+                ->slideOver()
+                ->modalHeading(trans('admin/monitoring.details.heading'))
+                ->modalSubmitAction(false)
+                ->modalCancelActionLabel(trans('admin/monitoring.details.close'))
+                ->disabled(fn (): bool => !$this->selectedNodeId)
+                ->form(function (): array {
+                    if (!$this->selectedNodeId) {
+                        return [
+                            Placeholder::make('no_data')
+                                ->hiddenLabel()
+                                ->content(trans('admin/monitoring.details.no_data')),
+                        ];
+                    }
+                    $node = Node::find($this->selectedNodeId);
+                    $data = $node ? $this->getMonitoringData($node) : null;
+                    return $this->buildDetailsForm($data);
+                }),
+
+            Action::make('refresh')
+                ->label(trans('admin/monitoring.actions.refresh'))
+                ->icon('heroicon-o-arrow-path')
+                ->action(fn () => $this->dispatch('refreshMonitoring')),
+        ];
+    }
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            \App\Filament\Widgets\NodeSelectorWidget::class,
+            \App\Filament\Widgets\MonitoringWidget::class,
+            \App\Filament\Widgets\ServersWidget::class,
+        ];
+    }
+
+    protected function getMonitoringData(Node $node): ?array
+    {
+        try {
+            $repository = app(DaemonMonitoringRepository::class);
+            $repository->setNode($node);
+            return $repository->getSystemMonitoring();
+        } catch (\Exception) {
+            return null;
+        }
+    }
+
+    protected function buildDetailsForm(?array $data): array
+    {
+        if (!$data) {
+            return [
+                Placeholder::make('no_data')
+                    ->hiddenLabel()
+                    ->content(trans('admin/monitoring.details.no_data')),
+            ];
+        }
+
+        return [
+            Section::make(trans('admin/monitoring.details.cpu_section'))
+                ->icon('heroicon-o-cpu-chip')
+                ->columns(2)
+                ->schema([
+                    Placeholder::make('cpu_total')
+                        ->label(trans('admin/monitoring.details.cpu_total'))
+                        ->content(number_format($data['cpu']['usage_percent'], 2) . '%'),
+
+                    Placeholder::make('cpu_cores')
+                        ->label(trans('admin/monitoring.details.cpu_cores'))
+                        ->content((string) $data['cpu']['cores']),
+
+                    Placeholder::make('cpu_per_core')
+                        ->label(trans('admin/monitoring.details.per_core'))
+                        ->columnSpanFull()
+                        ->content(function () use ($data): HtmlString {
+                            $cores = $data['cpu']['per_core'] ?? [];
+                            if (empty($cores)) {
+                                return new HtmlString('<span class="text-gray-400">—</span>');
+                            }
+                            $items = array_map(function (int $i, float $pct): string {
+                                $color = $pct >= 80 ? 'text-danger-500' : ($pct >= 50 ? 'text-warning-500' : 'text-success-500');
+                                return "<div class=\"text-xs\"><span class=\"text-gray-400\">Core {$i}</span> <span class=\"{$color} font-mono\">" . number_format($pct, 1) . "%</span></div>";
+                            }, array_keys($cores), $cores);
+                            return new HtmlString('<div class="grid grid-cols-4 gap-x-4 gap-y-1">' . implode('', $items) . '</div>');
+                        }),
+                ]),
+
+            Section::make(trans('admin/monitoring.details.memory_section'))
+                ->icon('heroicon-o-circle-stack')
+                ->columns(2)
+                ->schema([
+                    Placeholder::make('mem_total')
+                        ->label(trans('admin/monitoring.details.total_memory'))
+                        ->content($this->formatBytes($data['memory']['total_bytes'])),
+
+                    Placeholder::make('mem_used')
+                        ->label(trans('admin/monitoring.details.used_memory'))
+                        ->content($this->formatBytes($data['memory']['used_bytes'])),
+
+                    Placeholder::make('mem_free')
+                        ->label(trans('admin/monitoring.details.free_memory'))
+                        ->content($this->formatBytes($data['memory']['free_bytes'])),
+
+                    Placeholder::make('mem_available')
+                        ->label(trans('admin/monitoring.details.available_memory'))
+                        ->content($this->formatBytes($data['memory']['available_bytes'])),
+                ]),
+
+            Section::make(trans('admin/monitoring.details.swap_section'))
+                ->icon('heroicon-o-arrows-right-left')
+                ->columns(2)
+                ->schema(function () use ($data): array {
+                    $swapTotal = (int) ($data['memory']['swap_total_bytes'] ?? 0);
+                    if ($swapTotal === 0) {
+                        return [
+                            Placeholder::make('swap_none')
+                                ->hiddenLabel()
+                                ->content(trans('admin/monitoring.details.swap_none')),
+                        ];
+                    }
+                    return [
+                        Placeholder::make('swap_total')
+                            ->label(trans('admin/monitoring.details.swap_total'))
+                            ->content($this->formatBytes($swapTotal)),
+
+                        Placeholder::make('swap_used')
+                            ->label(trans('admin/monitoring.details.swap_used'))
+                            ->content($this->formatBytes((int) ($data['memory']['swap_used_bytes'] ?? 0))),
+
+                        Placeholder::make('swap_free')
+                            ->label(trans('admin/monitoring.details.swap_free'))
+                            ->content($this->formatBytes((int) ($data['memory']['swap_free_bytes'] ?? 0))),
+
+                        Placeholder::make('swap_pct')
+                            ->label(trans('admin/monitoring.details.swap_usage'))
+                            ->content(number_format((float) ($data['memory']['swap_usage_percent'] ?? 0), 2) . '%'),
+                    ];
+                }),
+
+            Section::make(trans('admin/monitoring.details.network_section'))
+                ->icon('heroicon-o-signal')
+                ->columns(2)
+                ->schema([
+                    Placeholder::make('net_sent')
+                        ->label(trans('admin/monitoring.details.bytes_sent'))
+                        ->content($this->formatBytes($data['network']['bytes_sent'])),
+
+                    Placeholder::make('net_recv')
+                        ->label(trans('admin/monitoring.details.bytes_recv'))
+                        ->content($this->formatBytes($data['network']['bytes_recv'])),
+
+                    Placeholder::make('net_pkts_sent')
+                        ->label(trans('admin/monitoring.details.packets_sent'))
+                        ->content(number_format($data['network']['packets_sent'])),
+
+                    Placeholder::make('net_pkts_recv')
+                        ->label(trans('admin/monitoring.details.packets_received'))
+                        ->content(number_format($data['network']['packets_recv'])),
+                ]),
+
+            Section::make(trans('admin/monitoring.details.runtime_section'))
+                ->icon('heroicon-o-cog-6-tooth')
+                ->columns(2)
+                ->schema([
+                    Placeholder::make('rt_go')
+                        ->label(trans('admin/monitoring.details.go_version'))
+                        ->content($data['runtime']['go_version']),
+
+                    Placeholder::make('rt_arch')
+                        ->label(trans('admin/monitoring.details.arch'))
+                        ->content($data['runtime']['arch'] ?? '—'),
+
+                    Placeholder::make('rt_goroutines')
+                        ->label(trans('admin/monitoring.details.goroutines'))
+                        ->content((string) $data['runtime']['goroutines']),
+
+                    Placeholder::make('rt_uptime')
+                        ->label(trans('admin/monitoring.details.uptime'))
+                        ->content($this->formatUptime($data['runtime']['uptime_seconds'])),
+                ]),
+        ];
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $bytes = max($bytes, 0);
+        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+        $pow = min($pow, count($units) - 1);
+        $bytes /= (1 << (10 * $pow));
+        return round($bytes, 2) . ' ' . $units[$pow];
+    }
+
+    private function formatUptime(int $seconds): string
+    {
+        $days = floor($seconds / 86400);
+        $hours = floor(($seconds % 86400) / 3600);
+        $minutes = floor(($seconds % 3600) / 60);
+        if ($days > 0) return "{$days}d {$hours}h {$minutes}m";
+        if ($hours > 0) return "{$hours}h {$minutes}m";
+        return "{$minutes}m";
+    }
+}

--- a/app/Filament/Widgets/MonitoringWidget.php
+++ b/app/Filament/Widgets/MonitoringWidget.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Node;
+use App\Repositories\Wings\DaemonMonitoringRepository;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\On;
+
+class MonitoringWidget extends BaseWidget
+{
+    protected static bool $isDiscoverable = false;
+
+    public ?int $selectedNodeId = null;
+
+    /** @var float[] Rolling history for chart sparklines (max 10 points each) */
+    public array $cpuHistory    = [];
+    public array $memoryHistory = [];
+    public array $diskHistory   = [];
+
+    private const HISTORY_MAX = 10;
+
+    protected static ?int $sort = 1;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected ?string $pollingInterval = '1s';
+
+    public function mount(): void
+    {
+    }
+
+    #[On('nodeChanged')]
+    public function updateNodeId(?int $nodeId = null): void
+    {
+        if ($nodeId && $nodeId !== $this->selectedNodeId) {
+            $this->selectedNodeId = $nodeId;
+            $this->cpuHistory     = [];
+            $this->memoryHistory  = [];
+            $this->diskHistory    = [];
+        }
+    }
+
+    #[On('refreshMonitoring')]
+    public function refreshData(): void
+    {
+        // force re-render
+    }
+
+    protected function getStats(): array
+    {
+        if (!$this->selectedNodeId) {
+            return [];
+        }
+
+        try {
+            $node = Node::findOrFail($this->selectedNodeId);
+        } catch (ModelNotFoundException) {
+            $this->selectedNodeId = null;
+            return $this->getErrorStats(trans('admin/monitoring.stats.error_node_gone'));
+        }
+
+        $data = $this->getMonitoringData($node);
+
+        if ($data === null) {
+            return $this->getErrorStats(trans('admin/monitoring.stats.error_fetch'));
+        }
+
+        return [
+            Stat::make(trans('admin/monitoring.stats.cpu_usage'), number_format($data['cpu']['usage_percent'], 2) . '%')
+                ->description(trans('admin/monitoring.stats.cpu_cores', ['count' => $data['cpu']['cores']]))
+                ->descriptionIcon('heroicon-o-cpu-chip')
+                ->chart($this->pushHistory('cpuHistory', $data['cpu']['usage_percent']))
+                ->color($this->getColorForPercentage($data['cpu']['usage_percent']))
+                ->icon('heroicon-o-cpu-chip'),
+
+            Stat::make(trans('admin/monitoring.stats.memory_usage'), number_format($data['memory']['usage_percent'], 2) . '%')
+                ->description(
+                    $this->formatBytes($data['memory']['used_bytes']) . ' / ' .
+                    $this->formatBytes($data['memory']['total_bytes'])
+                )
+                ->descriptionIcon('heroicon-o-circle-stack')
+                ->chart($this->pushHistory('memoryHistory', $data['memory']['usage_percent']))
+                ->color($this->getColorForPercentage($data['memory']['usage_percent']))
+                ->icon('heroicon-o-circle-stack'),
+
+            Stat::make(trans('admin/monitoring.stats.disk_usage'), number_format($data['disk']['usage_percent'], 2) . '%')
+                ->description(
+                    $this->formatBytes($data['disk']['used_bytes']) . ' / ' .
+                    $this->formatBytes($data['disk']['total_bytes'])
+                )
+                ->descriptionIcon('heroicon-o-server-stack')
+                ->chart($this->pushHistory('diskHistory', $data['disk']['usage_percent']))
+                ->color($this->getColorForPercentage($data['disk']['usage_percent']))
+                ->icon('heroicon-o-server-stack'),
+
+            Stat::make(trans('admin/monitoring.stats.network_traffic'), $this->formatBytes($data['network']['bytes_sent'] + $data['network']['bytes_recv']))
+                ->description(
+                    '↑ ' . $this->formatBytes($data['network']['bytes_sent']) . ' | ' .
+                    '↓ ' . $this->formatBytes($data['network']['bytes_recv'])
+                )
+                ->descriptionIcon('heroicon-o-signal')
+                ->color('info')
+                ->icon('heroicon-o-signal'),
+
+            Stat::make(trans('admin/monitoring.stats.uptime'), $this->formatUptime($data['runtime']['uptime_seconds']))
+                ->description(trans('admin/monitoring.stats.goroutines', ['count' => $data['runtime']['goroutines']]) . ' | ' . $data['runtime']['go_version'])
+                ->descriptionIcon('heroicon-o-clock')
+                ->color('success')
+                ->icon('heroicon-o-clock'),
+
+            Stat::make(trans('admin/monitoring.stats.last_updated'), date('H:i:s', $data['timestamp']))
+                ->description(date('Y-m-d', $data['timestamp']))
+                ->descriptionIcon('heroicon-o-calendar')
+                ->color('gray')
+                ->icon('heroicon-o-calendar'),
+        ];
+    }
+
+    protected function getMonitoringData(Node $node): ?array
+    {
+        try {
+            $repository = app(DaemonMonitoringRepository::class);
+            $repository->setNode($node);
+            return $repository->getSystemMonitoring();
+        } catch (\Throwable $e) {
+            Log::warning('MonitoringWidget: failed to fetch data for node ' . $node->id, [
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    protected function getErrorStats(string $message): array
+    {
+        return [
+            Stat::make(trans('admin/monitoring.stats.error'), trans('admin/monitoring.stats.error_desc'))
+                ->description($message)
+                ->descriptionIcon('heroicon-o-exclamation-triangle')
+                ->color('danger')
+                ->icon('heroicon-o-exclamation-triangle'),
+        ];
+    }
+
+    protected function getColorForPercentage(float $percentage): string
+    {
+        return match (true) {
+            $percentage >= 80 => 'danger',
+            $percentage >= 50 => 'warning',
+            default           => 'success',
+        };
+    }
+
+    protected function formatBytes(int|float $bytes): string
+    {
+        $bytes = max((float) $bytes, 0.0);
+        if ($bytes === 0.0) {
+            return '0 B';
+        }
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $pow   = (int) min(floor(log($bytes) / log(1024)), count($units) - 1);
+        return round($bytes / (1024 ** $pow), 2) . ' ' . $units[$pow];
+    }
+
+    protected function formatUptime(int $seconds): string
+    {
+        $days    = intdiv($seconds, 86400);
+        $hours   = intdiv($seconds % 86400, 3600);
+        $minutes = intdiv($seconds % 3600, 60);
+
+        if ($days > 0)  return "{$days}d {$hours}h {$minutes}m";
+        if ($hours > 0) return "{$hours}h {$minutes}m";
+        return "{$minutes}m";
+    }
+
+    /**
+     * Append $value to a rolling history Livewire property and return the array.
+     *
+     * @return float[]
+     */
+    protected function pushHistory(string $property, float $value): array
+    {
+        $this->{$property}[] = round($value, 2);
+
+        if (count($this->{$property}) > self::HISTORY_MAX) {
+            $this->{$property} = array_slice($this->{$property}, -self::HISTORY_MAX);
+        }
+
+        return $this->{$property};
+    }
+}

--- a/app/Filament/Widgets/NodeSelectorWidget.php
+++ b/app/Filament/Widgets/NodeSelectorWidget.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Node;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Schema;
+
+class NodeSelectorWidget extends BaseWidget
+{
+    protected static bool $isDiscoverable = false;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?int $sort = -1;
+
+    public ?int $nodeId = null;
+
+    public function mount(): void
+    {
+    }
+
+    public function updatedNodeId(): void
+    {
+        $this->dispatch('nodeChanged', nodeId: $this->nodeId);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('nodeId')
+                ->label(trans('admin/monitoring.selector.label'))
+                ->placeholder(trans('admin/monitoring.selector.placeholder'))
+                ->options(Node::query()->orderBy('name')->pluck('name', 'id'))
+                ->live()
+                ->afterStateUpdated(fn ($state) => $this->dispatch('nodeChanged', nodeId: $state)),
+        ]);
+    }
+}

--- a/app/Filament/Widgets/ServersWidget.php
+++ b/app/Filament/Widgets/ServersWidget.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Node;
+use App\Models\Server;
+use App\Repositories\Wings\DaemonServerStatusRepository;
+use Filament\Forms\Components\Placeholder;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\HtmlString;
+use Livewire\Attributes\On;
+
+class ServersWidget extends BaseWidget
+{
+    protected static bool $isDiscoverable = false;
+
+    public ?int $selectedNodeId = null;
+
+    protected static ?int $sort = 2;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected ?string $pollingInterval = '1s';
+
+    public function mount(): void
+    {
+    }
+
+    #[On('nodeChanged')]
+    public function updateNodeId(?int $nodeId = null): void
+    {
+        if ($nodeId && $nodeId !== $this->selectedNodeId) {
+            $this->selectedNodeId = $nodeId;
+        }
+    }
+
+    #[On('refreshMonitoring')]
+    public function refreshData(): void
+    {
+        // force re-render
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make(trans('admin/monitoring.servers.heading'))
+                ->icon('heroicon-o-server-stack')
+                ->schema([
+                    Placeholder::make('servers_table')
+                        ->hiddenLabel()
+                        ->content($this->buildTable()),
+                ]),
+        ]);
+    }
+
+    private function buildTable(): HtmlString
+    {
+        if (!$this->selectedNodeId) {
+            return $this->emptyState(trans('admin/monitoring.servers.no_node'), '#94a3b8');
+        }
+
+        $wingsRows = $this->fetchWingsData();
+
+        if ($wingsRows === null) {
+            return $this->emptyState(trans('admin/monitoring.servers.error_fetch'), '#f87171');
+        }
+
+        if (empty($wingsRows)) {
+            return $this->emptyState(trans('admin/monitoring.servers.no_servers'), '#94a3b8');
+        }
+
+        // Index Wings data by UUID for O(1) lookup.
+        $wingsByUuid = [];
+        foreach ($wingsRows as $row) {
+            $uuid = $row['configuration']['uuid'] ?? null;
+            if ($uuid) {
+                $wingsByUuid[$uuid] = $row;
+            }
+        }
+
+        // Fetch panel server names for those UUIDs.
+        $names = Server::query()
+            ->where('node_id', $this->selectedNodeId)
+            ->whereIn('uuid', array_keys($wingsByUuid))
+            ->pluck('name', 'uuid')
+            ->all();
+
+        $rows = '';
+        foreach ($wingsByUuid as $uuid => $row) {
+            $rows .= $this->buildRow($uuid, $row, $names[$uuid] ?? null);
+        }
+
+        $hName    = e(trans('admin/monitoring.servers.col.name'));
+        $hState   = e(trans('admin/monitoring.servers.col.state'));
+        $hCpu     = e(trans('admin/monitoring.servers.col.cpu'));
+        $hMemory  = e(trans('admin/monitoring.servers.col.memory'));
+        $hDisk    = e(trans('admin/monitoring.servers.col.disk'));
+        $hNetwork = e(trans('admin/monitoring.servers.col.network'));
+        $hUptime  = e(trans('admin/monitoring.servers.col.uptime'));
+
+        $thStyle = 'padding:10px 16px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:#64748b';
+
+        return new HtmlString(<<<HTML
+        <div style="overflow-x:auto;border-radius:8px">
+            <table style="width:100%;border-collapse:collapse;text-align:left">
+                <thead>
+                    <tr style="border-bottom:1px solid rgba(255,255,255,0.08)">
+                        <th style="{$thStyle}">{$hName}</th>
+                        <th style="{$thStyle}">{$hState}</th>
+                        <th style="{$thStyle};min-width:120px">{$hCpu}</th>
+                        <th style="{$thStyle};min-width:180px">{$hMemory}</th>
+                        <th style="{$thStyle}">{$hDisk}</th>
+                        <th style="{$thStyle}">{$hNetwork}</th>
+                        <th style="{$thStyle}">{$hUptime}</th>
+                    </tr>
+                </thead>
+                <tbody>{$rows}</tbody>
+            </table>
+        </div>
+        HTML);
+    }
+
+    private function buildRow(string $uuid, array $row, ?string $serverName): string
+    {
+        $state    = $row['state'] ?? 'unknown';
+        $util     = $row['utilization'] ?? [];
+
+        $cpuRaw   = (float) ($util['cpu_absolute'] ?? 0);
+        $memUsed  = (int) ($util['memory_bytes'] ?? 0);
+        $memLimit = (int) ($util['memory_limit_bytes'] ?? 0);
+        $disk     = (int) ($util['disk_bytes'] ?? 0);
+        $netRx    = (int) ($util['network']['rx_bytes'] ?? 0);
+        $netTx    = (int) ($util['network']['tx_bytes'] ?? 0);
+        $uptimeMs = (int) ($util['uptime'] ?? 0);
+
+        $name       = e($serverName ?? substr($uuid, 0, 8));
+        $cpuPct     = min($cpuRaw, 100);
+        $memPct     = $memLimit > 0 ? min(round($memUsed / $memLimit * 100, 1), 100) : 0;
+
+        $cpuLabel   = number_format($cpuRaw, 1) . '%';
+        $memLabel   = $this->formatBytes($memUsed) . ' / ' . $this->formatBytes($memLimit);
+        $diskLabel  = $this->formatBytes($disk);
+        $netRxLabel = $this->formatBytes($netRx);
+        $netTxLabel = $this->formatBytes($netTx);
+        $uptime     = $uptimeMs > 0 ? $this->formatUptime((int) ($uptimeMs / 1000)) : '—';
+
+        $cpuColor = $cpuPct >= 80 ? '#ef4444' : ($cpuPct >= 60 ? '#eab308' : '#22c55e');
+        $memColor = $memPct >= 80 ? '#ef4444' : ($memPct >= 60 ? '#eab308' : '#3b82f6');
+
+        [$badgeHtml, $avatarBorder] = $this->stateBadge($state);
+
+        $initial  = e(strtoupper(mb_substr($serverName ?? $uuid, 0, 1)));
+        $tdStyle  = 'padding:12px 16px;vertical-align:middle';
+
+        return <<<HTML
+        <tr style="border-bottom:1px solid rgba(255,255,255,0.05)">
+            <td style="{$tdStyle}">
+                <div style="display:flex;align-items:center;gap:10px">
+                    <div style="flex-shrink:0;width:32px;height:32px;border-radius:8px;background:rgba(255,255,255,0.06);border:1px solid {$avatarBorder};display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:#f1f5f9">{$initial}</div>
+                    <span style="font-size:13px;font-weight:500;color:#f1f5f9;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:160px" title="{$name}">{$name}</span>
+                </div>
+            </td>
+            <td style="{$tdStyle}">{$badgeHtml}</td>
+            <td style="{$tdStyle};min-width:120px">
+                <div style="font-size:11px;color:#94a3b8;font-family:monospace;margin-bottom:5px">{$cpuLabel}</div>
+                <div style="height:5px;width:100%;background:rgba(255,255,255,0.08);border-radius:9999px;overflow:hidden">
+                    <div style="height:100%;width:{$cpuPct}%;background:{$cpuColor};border-radius:9999px"></div>
+                </div>
+            </td>
+            <td style="{$tdStyle};min-width:180px">
+                <div style="font-size:11px;color:#94a3b8;font-family:monospace;margin-bottom:5px">{$memLabel}</div>
+                <div style="height:5px;width:100%;background:rgba(255,255,255,0.08);border-radius:9999px;overflow:hidden">
+                    <div style="height:100%;width:{$memPct}%;background:{$memColor};border-radius:9999px"></div>
+                </div>
+            </td>
+            <td style="{$tdStyle};font-size:12px;color:#94a3b8;font-family:monospace">{$diskLabel}</td>
+            <td style="{$tdStyle}">
+                <div style="font-family:monospace;font-size:11px;line-height:1.7">
+                    <div style="color:#4ade80">↓ {$netRxLabel}</div>
+                    <div style="color:#60a5fa">↑ {$netTxLabel}</div>
+                </div>
+            </td>
+            <td style="{$tdStyle};font-size:12px;color:#94a3b8;font-family:monospace">{$uptime}</td>
+        </tr>
+        HTML;
+    }
+
+    private function stateBadge(string $state): array
+    {
+        [$bg, $textColor, $dotColor, $border] = match ($state) {
+            'running'  => ['rgba(34,197,94,0.12)',  '#4ade80', '#22c55e', 'rgba(34,197,94,0.5)'],
+            'starting' => ['rgba(234,179,8,0.12)',  '#facc15', '#eab308', 'rgba(234,179,8,0.5)'],
+            'stopping' => ['rgba(249,115,22,0.12)', '#fb923c', '#f97316', 'rgba(249,115,22,0.5)'],
+            'offline'  => ['rgba(148,163,184,0.08)','#94a3b8', '#64748b', 'rgba(148,163,184,0.3)'],
+            'crashed'  => ['rgba(239,68,68,0.12)',  '#f87171', '#ef4444', 'rgba(239,68,68,0.5)'],
+            default    => ['rgba(148,163,184,0.08)','#94a3b8', '#64748b', 'rgba(148,163,184,0.3)'],
+        };
+
+        $label = e(ucfirst($state));
+
+        $badge = <<<HTML
+        <span style="display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border-radius:9999px;font-size:11px;font-weight:600;background:{$bg};color:{$textColor};border:1px solid {$border}">
+            <span style="width:6px;height:6px;border-radius:50%;background:{$dotColor};flex-shrink:0"></span>
+            {$label}
+        </span>
+        HTML;
+
+        return [$badge, $border];
+    }
+
+    private function emptyState(string $message, string $color): HtmlString
+    {
+        $msg = e($message);
+        return new HtmlString(<<<HTML
+        <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;padding:48px 0;gap:12px">
+            <svg style="width:40px;height:40px" fill="none" viewBox="0 0 24 24" stroke="#4b5563" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
+            </svg>
+            <p style="font-size:13px;color:{$color}">{$msg}</p>
+        </div>
+        HTML);
+    }
+
+    private function fetchWingsData(): ?array
+    {
+        try {
+            $node = Node::find($this->selectedNodeId);
+            if (!$node) {
+                return [];
+            }
+            $repository = app(DaemonServerStatusRepository::class);
+            $repository->setNode($node);
+            return $repository->getAllServerStatus();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function formatBytes(int|float $bytes): string
+    {
+        $bytes = max((float) $bytes, 0.0);
+        if ($bytes === 0.0) {
+            return '0 B';
+        }
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $pow   = (int) min(floor(log($bytes) / log(1024)), count($units) - 1);
+        return round($bytes / (1024 ** $pow), 2) . ' ' . $units[$pow];
+    }
+
+    private function formatUptime(int $seconds): string
+    {
+        $days    = intdiv($seconds, 86400);
+        $hours   = intdiv($seconds % 86400, 3600);
+        $minutes = intdiv($seconds % 3600, 60);
+
+        if ($days > 0)  return "{$days}d {$hours}h {$minutes}m";
+        if ($hours > 0) return "{$hours}h {$minutes}m";
+        return "{$minutes}m";
+    }
+}

--- a/app/Http/Controllers/Admin/Settings/MailController.php
+++ b/app/Http/Controllers/Admin/Settings/MailController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Settings;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Mail\Message;
+use App\Http\Controllers\Controller;
+
+class MailController extends Controller
+{
+    /**
+     * Send a test email to the currently authenticated administrator
+     * to verify that mail settings are configured correctly.
+     */
+    public function test(): JsonResponse
+    {
+        /** @var \App\Models\User $user */
+        $user = Auth::user();
+
+        try {
+            Mail::raw(
+                'This is a test email sent from ' . config('app.name') . ' to confirm that your mail configuration is working correctly.',
+                function (Message $message) use ($user) {
+                    $message->to($user->email, $user->name_first . ' ' . $user->name_last)
+                        ->subject('[' . config('app.name') . '] Test Email');
+                }
+            );
+        } catch (\Exception $exception) {
+            return new JsonResponse([
+                'error' => 'Failed to send test email: ' . $exception->getMessage(),
+            ], 500);
+        }
+
+        return new JsonResponse([], 204);
+    }
+}

--- a/app/Repositories/Wings/DaemonMonitoringRepository.php
+++ b/app/Repositories/Wings/DaemonMonitoringRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Repositories\Wings;
+
+use Exception;
+use GuzzleHttp\Exception\GuzzleException;
+
+class DaemonMonitoringRepository extends DaemonRepository
+{
+    /**
+     * Get real-time system monitoring data from the Wings daemon.
+     *
+     * @return array
+     * @throws GuzzleException
+     */
+    public function getSystemMonitoring(): array
+    {
+        try {
+            $response = $this->getHttpClient()->get('/api/system/monitoring');
+
+            return json_decode($response->getBody()->__toString(), true);
+        } catch (Exception $exception) {
+            throw $exception;
+        }
+    }
+}

--- a/app/Repositories/Wings/DaemonServerStatusRepository.php
+++ b/app/Repositories/Wings/DaemonServerStatusRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Repositories\Wings;
+
+use Exception;
+use GuzzleHttp\Exception\GuzzleException;
+
+class DaemonServerStatusRepository extends DaemonRepository
+{
+    /**
+     * Fetch the status and resource utilization of all servers on this node.
+     *
+     * Wings returns an array of APIResponse objects, each containing:
+     *   - state        (string)  e.g. "running", "offline", "starting"
+     *   - is_suspended (bool)
+     *   - utilization  (object)  cpu_absolute, memory_bytes, memory_limit_bytes,
+     *                            disk_bytes, network.rx_bytes, network.tx_bytes, uptime
+     *   - configuration.uuid (string)
+     *
+     * @return array<int, array>
+     * @throws GuzzleException
+     */
+    public function getAllServerStatus(): array
+    {
+        try {
+            $response = $this->getHttpClient()->get('/api/servers');
+
+            return json_decode($response->getBody()->__toString(), true) ?? [];
+        } catch (Exception $exception) {
+            throw $exception;
+        }
+    }
+}

--- a/resources/lang/en/admin/monitoring.php
+++ b/resources/lang/en/admin/monitoring.php
@@ -1,0 +1,92 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Monitoring',
+        'group' => 'Administration',
+    ],
+
+    'page' => [
+        'title' => 'Monitoring',
+        'heading' => 'Live Monitoring',
+    ],
+
+    'actions' => [
+        'refresh' => 'Refresh Data',
+    ],
+
+    'selector' => [
+        'label' => 'Select Node',
+        'placeholder' => 'Select a node...',
+    ],
+
+    'stats' => [
+        'cpu_usage' => 'CPU Usage',
+        'cpu_cores' => ':count cores available',
+        'memory_usage' => 'Memory Usage',
+        'disk_usage' => 'Disk Usage',
+        'network_traffic' => 'Network Traffic',
+        'uptime' => 'Uptime',
+        'goroutines' => ':count goroutines',
+        'last_updated' => 'Last Updated',
+        'no_node' => 'No Node Selected',
+        'no_node_desc' => 'Please select a node to view monitoring data',
+        'no_node_hint' => 'Use the dropdown above',
+        'error' => 'Error',
+        'error_desc' => 'Unable to load monitoring data',
+        'error_fetch' => 'Unable to fetch data from Wings',
+        'error_node_gone' => 'Node no longer exists',
+    ],
+
+    'details' => [
+        'heading' => 'System Details',
+        'button' => 'Details',
+        'close' => 'Close',
+        'no_data' => 'No data available. Ensure the node is online.',
+
+        'cpu_section' => 'CPU',
+        'cpu_total' => 'Total Usage',
+        'cpu_cores' => 'Cores',
+        'per_core' => 'Per-Core Usage',
+
+        'memory_section' => 'Memory',
+        'total_memory' => 'Total',
+        'used_memory' => 'Used',
+        'free_memory' => 'Free',
+        'available_memory' => 'Available',
+
+        'swap_section' => 'Swap',
+        'swap_none' => 'No swap configured on this node.',
+        'swap_total' => 'Total',
+        'swap_used' => 'Used',
+        'swap_free' => 'Free',
+        'swap_usage' => 'Usage',
+
+        'network_section' => 'Network',
+        'bytes_sent' => 'Bytes Sent',
+        'bytes_recv' => 'Bytes Received',
+        'packets_sent' => 'Packets Sent',
+        'packets_received' => 'Packets Received',
+
+        'runtime_section' => 'Runtime',
+        'go_version' => 'Go Version',
+        'arch' => 'Architecture',
+        'goroutines' => 'Goroutines',
+        'uptime' => 'Uptime',
+    ],
+    'servers' => [
+        'heading'     => 'Server Usage',
+        'no_node'     => 'Select a node to view server usage.',
+        'no_servers'  => 'No servers found on this node.',
+        'error_fetch' => 'Unable to fetch server data from Wings.',
+        'col' => [
+            'name'    => 'Server',
+            'state'   => 'State',
+            'cpu'     => 'CPU',
+            'memory'  => 'Memory',
+            'disk'    => 'Disk',
+            'network' => 'Network',
+            'uptime'  => 'Uptime',
+        ],
+    ],
+];

--- a/resources/views/filament/pages/monitoring.blade.php
+++ b/resources/views/filament/pages/monitoring.blade.php
@@ -1,0 +1,19 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <x-slot name="heading">
+            Select Node
+        </x-slot>
+        
+        <x-filament::input.wrapper>
+            <x-filament::input.select wire:model.live="nodeId">
+                @foreach($nodes as $id => $name)
+                    <option value="{{ $id }}">{{ $name }}</option>
+                @endforeach
+            </x-filament::input.select>
+        </x-filament::input.wrapper>
+    </x-filament::section>
+
+    @foreach ($this->getHeaderWidgetsData() as $widget)
+        @livewire(\Livewire\Livewire::getAlias($widget['class']), $widget['data'], key($widget['class']))
+    @endforeach
+</x-filament-panels::page>


### PR DESCRIPTION
- Implemented Monitoring page with node selection and real-time data display.
- Added MonitoringWidget for CPU, memory, disk, and network statistics.
- Created NodeSelectorWidget for selecting nodes to monitor.
- Developed ServersWidget to display server usage and status.
- Introduced DaemonMonitoringRepository and DaemonServerStatusRepository for data fetching.
- Added localization for monitoring-related strings.
- Created MailController for testing email configuration.