### PR TITLE
feat(designify): support multiple announcements with legacy fallback

### DIFF
--- a/app/Http/Requests/Admin/Designify/AlertSettingsFormRequest.php
+++ b/app/Http/Requests/Admin/Designify/AlertSettingsFormRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Admin\Designify;
 
 use App\Http\Requests\Admin\AdminFormRequest;
+use Illuminate\Support\Collection;
 
 class AlertSettingsFormRequest extends AdminFormRequest
 {
@@ -12,16 +13,45 @@ class AlertSettingsFormRequest extends AdminFormRequest
     public function rules(): array
     {
         return [
-            'designify:alertType' => 'required|string',
-            'designify:alertMessage' => 'required|string',
+            'alerts' => 'required|array|min:1',
+            'alerts.*.type' => 'required|string|in:info,announcement,success,warning,danger,disabled',
+            'alerts.*.message' => 'required|string',
         ];
     }
 
     public function attributes(): array
     {
         return [
-            'designify:alertType' => 'Alert Type',
-            'designify:alertMessage' => 'Alert Message',
+            'alerts' => 'Alerts',
+            'alerts.*.type' => 'Alert Type',
+            'alerts.*.message' => 'Alert Message',
+        ];
+    }
+
+    /**
+     * Return only the settings keys expected by the alert controller.
+     */
+    public function normalize(?array $only = null): array
+    {
+        $alerts = Collection::make($this->input('alerts', []))
+            ->map(function ($alert): array {
+                return [
+                    'type' => (string) data_get($alert, 'type', 'info'),
+                    'message' => (string) data_get($alert, 'message', ''),
+                ];
+            })
+            ->values()
+            ->all();
+
+        $firstAlert = $alerts[0] ?? [
+            'type' => 'info',
+            'message' => '',
+        ];
+
+        return [
+            'designify:alerts' => json_encode($alerts, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '[]',
+            'designify:alertType' => $firstAlert['type'],
+            'designify:alertMessage' => $firstAlert['message'],
         ];
     }
 }

--- a/app/Http/ViewComposers/DesignifyComposer.php
+++ b/app/Http/ViewComposers/DesignifyComposer.php
@@ -159,6 +159,7 @@ class DesignifyComposer
             'fontFamily' => config('designify.fontFamily') ?? 'Poppins',
             'alertType' => config('designify.alertType') ?? 'info',
             'alertMessage' => config('designify.alertMessage') ?? '**Welcome to Reviactyl!** You can modify Theme Look & Feel using [Designify](/admin/designify) at the administration area.',
+            'alerts' => $this->getAlertsConfig(),
             'site_color' => config('designify.site_color') ?? '#3b82f6',
             'site_title' => config('designify.site_title') ?? 'Reviactyl',
             'site_description' => config('designify.site_description') ?? 'Our official control panel made better with Reviactyl.',
@@ -169,6 +170,42 @@ class DesignifyComposer
             'billingCardLink' => config('designify.billingCardLink') ?? '',
             'alwaysShowKillButton' => config('designify.alwaysShowKillButton', false),
         ];
+    }
+
+    private function getAlertsConfig(): array
+    {
+        $fallback = [[
+            'type' => config('designify.alertType') ?? 'info',
+            'message' => config('designify.alertMessage') ?? '**Welcome to Reviactyl!** You can modify Theme Look & Feel using [Designify](/admin/designify) at the administration area.',
+        ]];
+
+        $alerts = config('designify.alerts');
+
+        if (is_string($alerts)) {
+            $decoded = json_decode($alerts, true);
+            $alerts = is_array($decoded) ? $decoded : [];
+        }
+
+        if (!is_array($alerts) || empty($alerts)) {
+            return $fallback;
+        }
+
+        $normalized = [];
+        foreach ($alerts as $alert) {
+            if (!is_array($alert)) {
+                continue;
+            }
+
+            $type = (string) ($alert['type'] ?? 'info');
+            $message = (string) ($alert['message'] ?? '');
+
+            $normalized[] = [
+                'type' => $type,
+                'message' => $message,
+            ];
+        }
+
+        return empty($normalized) ? $fallback : $normalized;
     }
 
     public function compose(View $view): void

--- a/app/Providers/DesignifyServiceProvider.php
+++ b/app/Providers/DesignifyServiceProvider.php
@@ -43,6 +43,7 @@ class DesignifyServiceProvider extends ServiceProvider
         "designify:fontFamily",
         "designify:alertType",
         "designify:alertMessage",
+        "designify:alerts",
         "designify:site_color",
         "designify:site_title",
         "designify:site_description",
@@ -171,22 +172,24 @@ class DesignifyServiceProvider extends ServiceProvider
         foreach ($this->keys as $key) {
             $value = array_get($values, 'settings::' . $key, $config->get(str_replace(':', '.', $key)));
 
-            switch (strtolower($value)) {
-                case 'true':
-                case '(true)':
-                    $value = true;
-                    break;
-                case 'false':
-                case '(false)':
-                    $value = false;
-                    break;
-                case 'empty':
-                case '(empty)':
-                    $value = '';
-                    break;
-                case 'null':
-                case '(null)':
-                    $value = null;
+            if (is_string($value)) {
+                switch (strtolower($value)) {
+                    case 'true':
+                    case '(true)':
+                        $value = true;
+                        break;
+                    case 'false':
+                    case '(false)':
+                        $value = false;
+                        break;
+                    case 'empty':
+                    case '(empty)':
+                        $value = '';
+                        break;
+                    case 'null':
+                    case '(null)':
+                        $value = null;
+                }
             }
 
             $config->set(str_replace(':', '.', $key), $value);

--- a/config/designify.php
+++ b/config/designify.php
@@ -38,6 +38,7 @@ return [
 
     'alertType' => 'info',
     'alertMessage' => '**Welcome to Reviactyl!** You can modify Theme Look & Feel using [Designify](/admin/designify) at the administration area.',
+    'alerts' => '[{"type":"info","message":"**Welcome to Reviactyl!** You can modify Theme Look & Feel using [Designify](/admin/designify) at the administration area."}]',
 
     'statusCardLink' => '',
     'supportCardLink' => '',

--- a/resources/scripts/reviactyl/ui/Announcement.tsx
+++ b/resources/scripts/reviactyl/ui/Announcement.tsx
@@ -1,5 +1,6 @@
 import { useStoreState } from 'easy-peasy';
 import { ApplicationStore } from '@/state';
+import { ReviactylAlert } from '@/state/reviactyl';
 import Md2React from '@/reviactyl/ui/Md2React';
 import { BellIcon, CheckIcon, ExclamationIcon, InboxInIcon, InformationCircleIcon } from '@heroicons/react/solid';
 import styled from 'styled-components';
@@ -13,51 +14,58 @@ const AlertContainer = styled.div`
     ${tw`mx-auto w-full flex items-center gap-x-3 max-w-[1200px] p-3 mt-2 rounded-ui text-gray-100 !border-t-0 !border-r-0 !border-b-0 !border-l-4`}
 `;
 
+const getAlertClass = (type: string): string =>
+    type === 'info'
+        ? 'bg-blue-500/10 border-blue-500'
+        : type === 'announcement'
+        ? 'bg-reviactyl/10 border-reviactyl'
+        : type === 'danger'
+        ? 'bg-danger/10 border-danger'
+        : type === 'success'
+        ? 'bg-success/10 border-success'
+        : type === 'warning'
+        ? 'bg-yellow-500/10 border-yellow-500'
+        : '';
+
+const getAlertIcon = (type: string) =>
+    type === 'info' ? (
+        <InformationCircleIcon className='h-5 w-5 font-bold !text-blue-500' />
+    ) : type === 'announcement' ? (
+        <BellIcon className='h-5 w-5 font-bold !text-reviactyl' />
+    ) : type === 'danger' ? (
+        <InboxInIcon className='h-5 w-5 font-bold !text-danger/50' />
+    ) : type === 'success' ? (
+        <CheckIcon className='h-5 w-5 font-bold !text-success/50' />
+    ) : type === 'warning' ? (
+        <ExclamationIcon className='h-5 w-5 font-bold !text-yellow-500' />
+    ) : (
+        ''
+    );
+
 const Announcement = () => {
-    const alertType = useStoreState((state: ApplicationStore) => state.reviactyl.data!.alertType);
-    const alertMessage = useStoreState((state: ApplicationStore) => state.reviactyl.data!.alertMessage);
+    const reviactyl = useStoreState((state: ApplicationStore) => state.reviactyl.data);
+    const configuredAlerts = reviactyl?.alerts ?? [];
+    const fallbackAlertType = reviactyl?.alertType;
+    const fallbackAlertMessage = reviactyl?.alertMessage;
+    const alerts: ReviactylAlert[] =
+        configuredAlerts.length > 0
+            ? configuredAlerts
+            : fallbackAlertType && fallbackAlertMessage
+            ? [{ type: fallbackAlertType, message: fallbackAlertMessage }]
+            : [];
+
     return (
         <Container>
-            {alertType !== 'disabled' ? (
-                <AlertContainer
-                    className={`
-               ${
-                   alertType === 'info'
-                       ? 'bg-blue-500/10 border-blue-500'
-                       : alertType === 'announcement'
-                       ? 'bg-reviactyl/10 border-reviactyl'
-                       : alertType === 'danger'
-                       ? 'bg-danger/10 border-danger'
-                       : alertType === 'success'
-                       ? 'bg-success/10 border-success'
-                       : alertType === 'warning'
-                       ? 'bg-yellow-500/10 border-yellow-500'
-                       : ''
-               }
-            `}
-                >
-                    <div>
-                        {alertType === 'info' ? (
-                            <InformationCircleIcon className='h-5 w-5 font-bold !text-blue-500' />
-                        ) : alertType === 'announcement' ? (
-                            <BellIcon className='h-5 w-5 font-bold !text-reviactyl' />
-                        ) : alertType === 'danger' ? (
-                            <InboxInIcon className='h-5 w-5 font-bold !text-danger/50' />
-                        ) : alertType === 'success' ? (
-                            <CheckIcon className='h-5 w-5 font-bold !text-success/50' />
-                        ) : alertType === 'warning' ? (
-                            <ExclamationIcon className='h-5 w-5 font-bold !text-yellow-500' />
-                        ) : (
-                            ''
-                        )}
-                    </div>
-                    <div>
-                        <Md2React markdown={alertMessage} />
-                    </div>
-                </AlertContainer>
-            ) : (
-                ''
-            )}
+            {alerts
+                .filter((alert) => alert.type !== 'disabled')
+                .map((alert, index) => (
+                    <AlertContainer key={`${index}-${alert.type}-${alert.message.slice(0, 20)}`} className={getAlertClass(alert.type)}>
+                        <div>{getAlertIcon(alert.type)}</div>
+                        <div>
+                            <Md2React markdown={alert.message} />
+                        </div>
+                    </AlertContainer>
+                ))}
         </Container>
     );
 };

--- a/resources/scripts/state/reviactyl.ts
+++ b/resources/scripts/state/reviactyl.ts
@@ -1,5 +1,10 @@
 import { action, Action } from 'easy-peasy';
 
+export interface ReviactylAlert {
+    type: string;
+    message: string;
+}
+
 export interface ReviactylSettings {
     customCopyright: boolean;
     copyright: string;
@@ -10,6 +15,7 @@ export interface ReviactylSettings {
     allocationBlur: boolean;
     alertType: string;
     alertMessage: string;
+    alerts?: ReviactylAlert[];
     statusCardLink: string;
     supportCardLink: string;
     billingCardLink: string;

--- a/resources/views/admin/designify/alerts.blade.php
+++ b/resources/views/admin/designify/alerts.blade.php
@@ -5,45 +5,167 @@
 @endsection
 
 @section('content')
+    @php
+        $fallbackMessage = '**Welcome to Reviactyl!** You can modify Theme Look & Feel using [Designify](/admin/designify) at the administration area.';
+        $configuredAlerts = config('designify.alerts');
+
+        if (is_string($configuredAlerts)) {
+            $decodedAlerts = json_decode($configuredAlerts, true);
+            $configuredAlerts = is_array($decodedAlerts) ? $decodedAlerts : [];
+        }
+
+        if (!is_array($configuredAlerts) || empty($configuredAlerts)) {
+            $configuredAlerts = [[
+                'type' => config('designify.alertType', 'info'),
+                'message' => config('designify.alertMessage', $fallbackMessage),
+            ]];
+        }
+    @endphp
+
     <form id="designifyEditor" action="" method="POST" class="h-full flex flex-col">
         @csrf
         @method('PATCH')
         <div class="mb-8">
             <h1 class="text-2xl font-bold text-white mb-2">Alert settings</h1>
-            <p class="text-zinc-400 text-sm">Change the alert settings of Reviactyl Theme.</p>
+            <p class="text-zinc-400 text-sm">Create one or more alerts with custom type and message.</p>
         </div>
         <div class="flex-1 space-y-6">
             <div class="space-y-3">
-                <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300" for="designify:alertType">
-                    Alert Type
-                </label>
-                <select name="designify:alertType" id="designify:alertType"
-                    class="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200">
-                    <option value="info" {{ old('designify:alertType', config('designify.alertType')) === 'info' ? 'selected' : '' }}>
-                        Info
-                    </option>
-                    <option value="announcement"
-                        {{ old('designify:alertType', config('designify.alertType')) === 'announcement' ? 'selected' : '' }}>
-                        Announcement
-                    </option>
-                    <option value="success" {{ old('designify:alertType', config('designify.alertType')) === 'success' ? 'selected' : '' }}>
-                        Success
-                    </option>
-                    <option value="warning" {{ old('designify:alertType', config('designify.alertType')) === 'warning' ? 'selected' : '' }}>
-                        Warning
-                    </option>
-                    <option value="danger" {{ old('designify:alertType', config('designify.alertType')) === 'danger' ? 'selected' : '' }}>
-                        Danger
-                    </option>
-                    <option value="disabled" {{ old('designify:alertType', config('designify.alertType')) === 'disabled' ? 'selected' : '' }}>
-                        Disabled
-                    </option>
-                </select>
-                <input type="text" id="designify:alertMessage" name="designify:alertMessage"
-                    value="{{ old('designify:alertMessage', config('designify.alertMessage')) }}"
-                    class="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
-                    placeholder="**bold** [link](https://reviactyl.dev)" />
+                <div class="flex items-center justify-between">
+                    <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                        Alerts
+                    </label>
+                    <button id="add-alert" type="button"
+                        class="px-3 py-2 bg-zinc-700 hover:bg-zinc-600 text-white text-xs rounded-lg transition-colors duration-200">
+                        Add Alert
+                    </button>
+                </div>
+
+                <div id="alerts-list" class="space-y-4"></div>
+                <input type="hidden" name="designify:alerts" id="designify:alerts" value="">
             </div>
         </div>
     </form>
+
+    <script>
+        (() => {
+            const alertsList = document.getElementById('alerts-list');
+            const addAlertButton = document.getElementById('add-alert');
+            const hiddenAlertsField = document.getElementById('designify:alerts');
+            const form = document.getElementById('designifyEditor');
+            const validTypes = ['info', 'announcement', 'success', 'warning', 'danger', 'disabled'];
+            let alerts = @json(old('alerts', $configuredAlerts));
+
+            const escapeHtml = (value) => {
+                const div = document.createElement('div');
+                div.textContent = value;
+                return div.innerHTML;
+            };
+
+            const normalizeType = (type) => (validTypes.includes(type) ? type : 'info');
+
+            const normalizeAlert = (alert) => ({
+                type: normalizeType(alert && typeof alert.type === 'string' ? alert.type : 'info'),
+                message: alert && typeof alert.message === 'string' ? alert.message : '',
+            });
+
+            const serializeAlerts = () => {
+                hiddenAlertsField.value = JSON.stringify(alerts.map(normalizeAlert));
+            };
+
+            const typeOptions = (selectedType) => validTypes.map((type) => `
+                <option value="${type}" ${selectedType === type ? 'selected' : ''}>
+                    ${type.charAt(0).toUpperCase() + type.slice(1)}
+                </option>
+            `).join('');
+
+            const render = () => {
+                if (!Array.isArray(alerts)) {
+                    alerts = [];
+                }
+
+                alerts = alerts.map(normalizeAlert);
+
+                if (alerts.length === 0) {
+                    alerts.push({ type: 'info', message: '' });
+                }
+
+                alertsList.innerHTML = alerts.map((alert, index) => `
+                    <div class="p-4 bg-zinc-800/40 border border-zinc-700 rounded-xl space-y-3" data-index="${index}">
+                        <div class="flex items-center justify-between gap-3">
+                            <h3 class="text-sm text-zinc-200 font-medium">Alert #${index + 1}</h3>
+                            <button type="button" class="remove-alert px-2 py-1 text-xs bg-red-900/30 border border-red-700 text-red-300 rounded-lg hover:bg-red-800/40 disabled:opacity-50 disabled:cursor-not-allowed" data-index="${index}" ${alerts.length === 1 ? 'disabled' : ''}>
+                                Remove
+                            </button>
+                        </div>
+                        <select name="alerts[${index}][type]" class="alert-type w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200">
+                            ${typeOptions(alert.type)}
+                        </select>
+                        <input
+                            type="text"
+                            name="alerts[${index}][message]"
+                            class="alert-message w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
+                            placeholder="**bold** [link](https://reviactyl.dev)"
+                            value="${escapeHtml(alert.message)}"
+                        />
+                    </div>
+                `).join('');
+
+                serializeAlerts();
+            };
+
+            addAlertButton.addEventListener('click', () => {
+                alerts.push({ type: 'info', message: '' });
+                render();
+            });
+
+            alertsList.addEventListener('click', (event) => {
+                const target = event.target;
+                if (!(target instanceof HTMLElement) || !target.classList.contains('remove-alert')) {
+                    return;
+                }
+
+                const index = Number(target.dataset.index);
+                if (Number.isNaN(index)) {
+                    return;
+                }
+
+                alerts.splice(index, 1);
+                render();
+            });
+
+            const handleAlertFieldChange = (event) => {
+                const target = event.target;
+                if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) {
+                    return;
+                }
+
+                const wrapper = target.closest('[data-index]');
+                if (!(wrapper instanceof HTMLElement)) {
+                    return;
+                }
+
+                const index = Number(wrapper.dataset.index);
+                if (Number.isNaN(index) || !alerts[index]) {
+                    return;
+                }
+
+                if (target.classList.contains('alert-type')) {
+                    alerts[index].type = normalizeType(target.value);
+                }
+
+                if (target.classList.contains('alert-message')) {
+                    alerts[index].message = target.value;
+                }
+
+                serializeAlerts();
+            };
+
+            alertsList.addEventListener('input', handleAlertFieldChange);
+            alertsList.addEventListener('change', handleAlertFieldChange);
+
+            form.addEventListener('submit', serializeAlerts);
+            render();
+        })();
+    </script>
 @endsection


### PR DESCRIPTION
- Switched alert config from single fields to an alerts[] structure in AlertSettingsFormRequest validation.
- Added request normalization to store designify:alerts as JSON.                                                                                                                                                           
- Kept legacy writes for designify:alertType and designify:alertMessage (first alert) so older code paths still work.                                                                                                      
- Replaced the admin alert form with a JS-driven multi-row editor (add/remove, type/message per row, hidden JSON payload).                                                                                                 
- Registered designify:alerts in DesignifyServiceProvider and tightened value casting to only run on strings.                                                                                                              
- Added DesignifyComposer::getAlertsConfig() to decode/normalize alerts and fallback to legacy single-alert values.                                                                                                        
- Updated Announcement.tsx to render a list of alerts, ignore disabled, and use shared helpers for class/icon mapping.                                                                                                     
- Extended frontend types (ReviactylAlert, optional alerts) and added a default alerts JSON entry in config/designify.php.