### PR TITLE
feat(designify): add configurable sidebar buttons as requested in #229

### DIFF
--- a/app/Http/Controllers/Admin/Designify/SidebarButtonsController.php
+++ b/app/Http/Controllers/Admin/Designify/SidebarButtonsController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Designify;
+
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+use Prologue\Alerts\AlertsMessageBag;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\View\Factory as ViewFactory;
+use App\Http\Controllers\Controller;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use App\Contracts\Repository\SettingsRepositoryInterface;
+use App\Http\Requests\Admin\Designify\SidebarButtonsSettingsFormRequest;
+
+class SidebarButtonsController extends Controller
+{
+    /**
+     * SidebarButtonsController constructor.
+     */
+    public function __construct(
+        private AlertsMessageBag $alert,
+        private ConfigRepository $config,
+        private Kernel $kernel,
+        private SettingsRepositoryInterface $settings,
+        private ViewFactory $view,
+    ) {
+    }
+
+    /**
+     * Render Sidebar Buttons settings UI.
+     */
+    public function index(): View
+    {
+        return $this->view->make('admin.designify.sidebar-buttons');
+    }
+
+    /**
+     * Update sidebar button settings.
+     */
+    public function update(SidebarButtonsSettingsFormRequest $request): RedirectResponse
+    {
+        foreach ($request->normalize() as $key => $value) {
+            $this->settings->set('settings::' . $key, $value);
+        }
+
+        $this->kernel->call('queue:restart');
+        $this->alert->success('Sidebar button settings have been updated successfully.')->flash();
+
+        return redirect()->route('admin.designify.sidebar-buttons');
+    }
+}

--- a/app/Http/Requests/Admin/Designify/SidebarButtonsSettingsFormRequest.php
+++ b/app/Http/Requests/Admin/Designify/SidebarButtonsSettingsFormRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Requests\Admin\Designify;
+
+use Illuminate\Support\Collection;
+use App\Http\Requests\Admin\AdminFormRequest;
+
+class SidebarButtonsSettingsFormRequest extends AdminFormRequest
+{
+    /**
+     * Return all the rules to apply to this request's data.
+     */
+    public function rules(): array
+    {
+        return [
+            'sidebar_buttons' => 'nullable|array|max:12',
+            'sidebar_buttons.*.label' => 'nullable|string|max:60',
+            'sidebar_buttons.*.url' => 'nullable|string|max:255',
+            'sidebar_buttons.*.newTab' => 'nullable|boolean',
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'sidebar_buttons' => 'Sidebar Buttons',
+            'sidebar_buttons.*.label' => 'Button Label',
+            'sidebar_buttons.*.url' => 'Button URL',
+            'sidebar_buttons.*.newTab' => 'Open in New Tab',
+        ];
+    }
+
+    /**
+     * Return only the settings keys expected by the sidebar button controller.
+     */
+    public function normalize(?array $only = null): array
+    {
+        $buttons = Collection::make($this->input('sidebar_buttons', []))
+            ->filter(fn ($button): bool => is_array($button))
+            ->map(function (array $button): array {
+                $label = trim((string) data_get($button, 'label', ''));
+                $url = trim((string) data_get($button, 'url', ''));
+                $newTab = filter_var(data_get($button, 'newTab', false), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+
+                return [
+                    'label' => $label,
+                    'url' => $url,
+                    'newTab' => $newTab,
+                ];
+            })
+            ->filter(fn (array $button): bool => $button['label'] !== '' && $button['url'] !== '')
+            ->values()
+            ->all();
+
+        return [
+            'designify:sidebarButtons' => json_encode($buttons, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '[]',
+        ];
+    }
+}

--- a/app/Http/ViewComposers/DesignifyComposer.php
+++ b/app/Http/ViewComposers/DesignifyComposer.php
@@ -153,6 +153,7 @@ class DesignifyComposer
             'theme7' => $this->Theme7,
             'themeSelector' => config('designify.themeSelector', false),
             'sidebarLogout' => config('designify.sidebarLogout', false),
+            'sidebarButtons' => $this->getSidebarButtonsConfig(),
             'background' => config('designify.background') ?? 'none',
             'radius' => config('designify.radius') ?? '15px',
             'allocationBlur' => config('designify.allocationBlur', true),
@@ -206,6 +207,43 @@ class DesignifyComposer
         }
 
         return empty($normalized) ? $fallback : $normalized;
+    }
+
+    private function getSidebarButtonsConfig(): array
+    {
+        $buttons = config('designify.sidebarButtons');
+
+        if (is_string($buttons)) {
+            $decoded = json_decode($buttons, true);
+            $buttons = is_array($decoded) ? $decoded : [];
+        }
+
+        if (!is_array($buttons)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($buttons as $button) {
+            if (!is_array($button)) {
+                continue;
+            }
+
+            $label = trim((string) ($button['label'] ?? ''));
+            $url = trim((string) ($button['url'] ?? ''));
+            $newTab = filter_var($button['newTab'] ?? false, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+
+            if ($label === '' || $url === '') {
+                continue;
+            }
+
+            $normalized[] = [
+                'label' => $label,
+                'url' => $url,
+                'newTab' => $newTab,
+            ];
+        }
+
+        return $normalized;
     }
 
     public function compose(View $view): void

--- a/app/Providers/DesignifyServiceProvider.php
+++ b/app/Providers/DesignifyServiceProvider.php
@@ -37,6 +37,7 @@ class DesignifyServiceProvider extends ServiceProvider
         "designify:color900",
         "designify:themeSelector",
         "designify:sidebarLogout",
+        "designify:sidebarButtons",
         "designify:background",
         "designify:radius",
         "designify:allocationBlur",

--- a/config/designify.php
+++ b/config/designify.php
@@ -25,6 +25,7 @@ return [
 
     'themeSelector' => true,
     'sidebarLogout' => false,
+    'sidebarButtons' => '[]',
     'background' => 'none',
     'radius' => '15px',
     'allocationBlur' => true,

--- a/resources/scripts/reviactyl/ui/Sidebar.tsx
+++ b/resources/scripts/reviactyl/ui/Sidebar.tsx
@@ -124,9 +124,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(({ children, isOpen = fa
                 </div>
             </ProfileHeader>
 
-            <SidebarContent>
-                {children && <SideNavigation>{children}</SideNavigation>}
-            </SidebarContent>
+            <SidebarContent>{children ? <SideNavigation>{children}</SideNavigation> : null}</SidebarContent>
 
             {sidebarLogout && (
                 <SidebarFooter>

--- a/resources/scripts/reviactyl/ui/Sidebar.tsx
+++ b/resources/scripts/reviactyl/ui/Sidebar.tsx
@@ -5,6 +5,7 @@ import { Link, NavLink } from 'react-router-dom';
 import Avatar from '@/reviactyl/ui/Avatar';
 import { useStoreState } from 'easy-peasy';
 import { ApplicationStore } from '@/state';
+import { ReviactylSidebarButton } from '@/state/reviactyl';
 import { ExternalLinkIcon, LogoutIcon } from '@heroicons/react/solid';
 import { useTranslation } from 'react-i18next';
 import { FaHouse } from 'react-icons/fa6';
@@ -89,6 +90,15 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(({ children, isOpen = fa
     const name = useStoreState((state: ApplicationStore) => state.settings.data!.name);
     const [isLoggingOut, setIsLoggingOut] = useState(false);
     const sidebarLogout = useStoreState((state) => state.reviactyl.data?.sidebarLogout);
+    const customSidebarButtons = useStoreState((state) => state.reviactyl.data?.sidebarButtons ?? []);
+
+    const normalizedSidebarButtons = (Array.isArray(customSidebarButtons) ? customSidebarButtons : []).filter(
+        (button): button is ReviactylSidebarButton =>
+            typeof button?.label === 'string' &&
+            button.label.trim().length > 0 &&
+            typeof button?.url === 'string' &&
+            button.url.trim().length > 0
+    );
 
     const onLogout = () => {
         setIsLoggingOut(true);
@@ -136,7 +146,25 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(({ children, isOpen = fa
                         </NavLink>
                     </SideNavigation>
                 )}
-                {children && <SideNavigation>{children}</SideNavigation>}
+                {(children || (dashboard && normalizedSidebarButtons.length > 0)) && (
+                    <SideNavigation>
+                        {children}
+                        {dashboard &&
+                            normalizedSidebarButtons.map((button, index) => (
+                                <a
+                                    key={`${button.url}-${index}`}
+                                    href={button.url}
+                                    target={button.newTab === true ? '_blank' : undefined}
+                                    rel={button.newTab === true ? 'noopener noreferrer' : undefined}
+                                >
+                                    <span className='flex items-center'>
+                                        <ExternalLinkIcon className='w-4 h-4 mr-2' />
+                                        {button.label}
+                                    </span>
+                                </a>
+                            ))}
+                    </SideNavigation>
+                )}
             </SidebarContent>
 
             {sidebarLogout && (

--- a/resources/scripts/reviactyl/ui/Sidebar.tsx
+++ b/resources/scripts/reviactyl/ui/Sidebar.tsx
@@ -1,21 +1,18 @@
 import React, { useState } from 'react';
 import styled, { css } from 'styled-components';
 import tw from 'twin.macro';
-import { Link, NavLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import Avatar from '@/reviactyl/ui/Avatar';
 import { useStoreState } from 'easy-peasy';
 import { ApplicationStore } from '@/state';
-import { ReviactylSidebarButton } from '@/state/reviactyl';
 import { ExternalLinkIcon, LogoutIcon } from '@heroicons/react/solid';
 import { useTranslation } from 'react-i18next';
-import { FaHouse } from 'react-icons/fa6';
 import http from '@/api/http';
 import SpinnerOverlay from '@/components/elements/SpinnerOverlay';
 
 interface Props {
     isOpen?: boolean;
     children?: React.ReactNode;
-    dashboard?: boolean;
 }
 
 const Container = styled.div<{ $isOpen: boolean }>`
@@ -82,7 +79,7 @@ export const SideNavigation = styled.div`
     }
 `;
 
-const Sidebar = React.forwardRef<HTMLDivElement, Props>(({ children, isOpen = false, dashboard = false }, ref) => {
+const Sidebar = React.forwardRef<HTMLDivElement, Props>(({ children, isOpen = false }, ref) => {
     const { t } = useTranslation('routes');
     const nameFirst = useStoreState((state) => state.user.data?.name_first);
     const nameLast = useStoreState((state) => state.user.data?.name_last);
@@ -90,15 +87,6 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(({ children, isOpen = fa
     const name = useStoreState((state: ApplicationStore) => state.settings.data!.name);
     const [isLoggingOut, setIsLoggingOut] = useState(false);
     const sidebarLogout = useStoreState((state) => state.reviactyl.data?.sidebarLogout);
-    const customSidebarButtons = useStoreState((state) => state.reviactyl.data?.sidebarButtons ?? []);
-
-    const normalizedSidebarButtons = (Array.isArray(customSidebarButtons) ? customSidebarButtons : []).filter(
-        (button): button is ReviactylSidebarButton =>
-            typeof button?.label === 'string' &&
-            button.label.trim().length > 0 &&
-            typeof button?.url === 'string' &&
-            button.url.trim().length > 0
-    );
 
     const onLogout = () => {
         setIsLoggingOut(true);
@@ -137,34 +125,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, Props>(({ children, isOpen = fa
             </ProfileHeader>
 
             <SidebarContent>
-                {dashboard && (
-                    <SideNavigation>
-                        <NavLink className='mt-2' to='/' end>
-                            <span className='flex items-center'>
-                                <FaHouse className='w-5 mr-1' /> {t('index.dashboard')}
-                            </span>
-                        </NavLink>
-                    </SideNavigation>
-                )}
-                {(children || (dashboard && normalizedSidebarButtons.length > 0)) && (
-                    <SideNavigation>
-                        {children}
-                        {dashboard &&
-                            normalizedSidebarButtons.map((button, index) => (
-                                <a
-                                    key={`${button.url}-${index}`}
-                                    href={button.url}
-                                    target={button.newTab === true ? '_blank' : undefined}
-                                    rel={button.newTab === true ? 'noopener noreferrer' : undefined}
-                                >
-                                    <span className='flex items-center'>
-                                        <ExternalLinkIcon className='w-4 h-4 mr-2' />
-                                        {button.label}
-                                    </span>
-                                </a>
-                            ))}
-                    </SideNavigation>
-                )}
+                {children && <SideNavigation>{children}</SideNavigation>}
             </SidebarContent>
 
             {sidebarLogout && (

--- a/resources/scripts/routers/DashboardRouter.tsx
+++ b/resources/scripts/routers/DashboardRouter.tsx
@@ -9,7 +9,7 @@ import routes from '@/routers/routes';
 import { RouterContainer } from '@/reviactyl/ui/RouterContainer';
 import Navbar from '@/reviactyl/ui/Navbar';
 import { LogoContainer } from '@/reviactyl/ui/LogoContainer';
-import { XIcon, MenuIcon } from '@heroicons/react/solid';
+import { XIcon, MenuIcon, ExternalLinkIcon } from '@heroicons/react/solid';
 import tw from 'twin.macro';
 import { ContentContainer } from '@/reviactyl/ui/ContentContainer';
 import { motion } from 'framer-motion';
@@ -21,6 +21,8 @@ import MaintenanceAlert from '@/reviactyl/ui/MaintenanceAlert';
 import QuickLinks from '@/reviactyl/ui/QuickLinks';
 import Maintenance from '@/reviactyl/ui/Maintenance';
 import { useTranslation } from 'react-i18next';
+import { FaHouse } from 'react-icons/fa6';
+import { ReviactylSidebarButton } from '@/state/reviactyl';
 
 interface Props {
     route: any;
@@ -42,13 +44,50 @@ const NavItem = ({ route }: Props) => {
 };
 
 const DashboardNavigation = () => {
+    const { t } = useTranslation('routes');
+    const customSidebarButtons = useStoreState((state) => state.reviactyl.data?.sidebarButtons ?? []);
+    const normalizedSidebarButtons = (Array.isArray(customSidebarButtons) ? customSidebarButtons : []).filter(
+        (button): button is ReviactylSidebarButton =>
+            typeof button?.label === 'string' &&
+            button.label.trim().length > 0 &&
+            typeof button?.url === 'string' &&
+            button.url.trim().length > 0
+    );
+
     return (
         <>
-            {routes.account
-                .filter((route) => !!route.name)
-                .map((route) => (
-                    <NavItem key={route.name} route={route} />
-                ))}
+            <div>
+                <Navigate id='index.dashboard' to='/' end className='mt-2'>
+                    <span className='flex items-center'>
+                        <FaHouse className='w-5 mr-1' /> {t('index.dashboard')}
+                    </span>
+                </Navigate>
+
+                {routes.account
+                    .filter((route) => !!route.name)
+                    .map((route) => (
+                        <NavItem key={route.name} route={route} />
+                    ))}
+            </div>
+
+            {normalizedSidebarButtons.length > 0 && (
+                <div>
+                    <span className='label'>MORE</span>
+                    {normalizedSidebarButtons.map((button, index) => (
+                        <a
+                            key={`${button.url}-${index}`}
+                            href={button.url}
+                            target={button.newTab === true ? '_blank' : undefined}
+                            rel={button.newTab === true ? 'noopener noreferrer' : undefined}
+                        >
+                            <span className='flex items-center'>
+                                <ExternalLinkIcon className='w-4 h-4 mr-2' />
+                                {button.label}
+                            </span>
+                        </a>
+                    ))}
+                </div>
+            )}
         </>
     );
 };
@@ -95,7 +134,7 @@ function DashboardRouter() {
                             animate={{ opacity: 1 }}
                             transition={{ duration: 0.15, ease: 'easeIn' }}
                         >
-                            <Sidebar isOpen={isSidebarOpen} dashboard>
+                            <Sidebar isOpen={isSidebarOpen}>
                                 <DashboardNavigation />
                             </Sidebar>
                         </motion.div>

--- a/resources/scripts/routers/DashboardRouter.tsx
+++ b/resources/scripts/routers/DashboardRouter.tsx
@@ -63,15 +63,17 @@ const DashboardNavigation = () => {
                     </span>
                 </Navigate>
 
-                {routes.account
-                    .filter((route) => !!route.name)
-                    .map((route) => (
-                        <NavItem key={route.name} route={route} />
-                    ))}
+                <div className='mt-2'>
+                    {routes.account
+                        .filter((route) => !!route.name)
+                        .map((route) => (
+                            <NavItem key={route.name} route={route} />
+                        ))}
+                </div>
             </div>
 
             {normalizedSidebarButtons.length > 0 && (
-                <div>
+                <div className='mt-2'>
                     <span className='label'>MORE</span>
                     {normalizedSidebarButtons.map((button, index) => (
                         <a

--- a/resources/scripts/routers/ServerRouter.tsx
+++ b/resources/scripts/routers/ServerRouter.tsx
@@ -17,7 +17,7 @@ import ConflictStateRenderer from '@/components/server/ConflictStateRenderer';
 import PermissionRoute from '@/components/elements/PermissionRoute';
 import routes from '@/routers/routes';
 import Sidebar from '@/reviactyl/ui/Sidebar';
-import { XIcon, MenuIcon } from '@heroicons/react/solid';
+import { XIcon, MenuIcon, ExternalLinkIcon } from '@heroicons/react/solid';
 import { LogoContainer } from '@/reviactyl/ui/LogoContainer';
 import tw from 'twin.macro';
 import { RouterContainer } from '@/reviactyl/ui/RouterContainer';
@@ -28,6 +28,7 @@ import Announcement from '@/reviactyl/ui/Announcement';
 import MaintenanceAlert from '@/reviactyl/ui/MaintenanceAlert';
 import Maintenance from '@/reviactyl/ui/Maintenance';
 import { useTranslation } from 'react-i18next';
+import { ReviactylSidebarButton } from '@/state/reviactyl';
 
 interface NavItemProps {
     route: any;
@@ -65,6 +66,14 @@ const NavItem = ({ route }: NavItemProps) => {
 
 const ServerNavigation = () => {
     const { t } = useTranslation('server/index');
+    const customSidebarButtons = useStoreState((state) => state.reviactyl.data?.sidebarButtons ?? []);
+    const normalizedSidebarButtons = (Array.isArray(customSidebarButtons) ? customSidebarButtons : []).filter(
+        (button): button is ReviactylSidebarButton =>
+            typeof button?.label === 'string' &&
+            button.label.trim().length > 0 &&
+            typeof button?.url === 'string' &&
+            button.url.trim().length > 0
+    );
 
     return (
         <>
@@ -91,6 +100,25 @@ const ServerNavigation = () => {
                         ))}
                 </div>
             ))}
+
+            {normalizedSidebarButtons.length > 0 && (
+                <div>
+                    <span className='label'>MORE</span>
+                    {normalizedSidebarButtons.map((button, index) => (
+                        <a
+                            key={`${button.url}-${index}`}
+                            href={button.url}
+                            target={button.newTab === true ? '_blank' : undefined}
+                            rel={button.newTab === true ? 'noopener noreferrer' : undefined}
+                        >
+                            <span className='flex items-center'>
+                                <ExternalLinkIcon className='w-4 h-4 mr-2' />
+                                {button.label}
+                            </span>
+                        </a>
+                    ))}
+                </div>
+            )}
         </>
     );
 };

--- a/resources/scripts/state/reviactyl.ts
+++ b/resources/scripts/state/reviactyl.ts
@@ -5,6 +5,12 @@ export interface ReviactylAlert {
     message: string;
 }
 
+export interface ReviactylSidebarButton {
+    label: string;
+    url: string;
+    newTab: boolean;
+}
+
 export interface ReviactylSettings {
     customCopyright: boolean;
     copyright: string;
@@ -16,6 +22,7 @@ export interface ReviactylSettings {
     alertType: string;
     alertMessage: string;
     alerts?: ReviactylAlert[];
+    sidebarButtons?: ReviactylSidebarButton[];
     statusCardLink: string;
     supportCardLink: string;
     billingCardLink: string;

--- a/resources/views/admin/designify/sidebar-buttons.blade.php
+++ b/resources/views/admin/designify/sidebar-buttons.blade.php
@@ -1,0 +1,170 @@
+@extends('layouts.designify', ['sideEditor' => true])
+
+@section('title')
+    Sidebar Buttons
+@endsection
+
+@section('content')
+    @php
+        $configuredButtons = config('designify.sidebarButtons');
+
+        if (is_string($configuredButtons)) {
+            $decodedButtons = json_decode($configuredButtons, true);
+            $configuredButtons = is_array($decodedButtons) ? $decodedButtons : [];
+        }
+
+        if (!is_array($configuredButtons)) {
+            $configuredButtons = [];
+        }
+    @endphp
+
+    <form id="designifyEditor" action="" method="POST" class="h-full flex flex-col">
+        @csrf
+        @method('PATCH')
+        <div class="mb-8">
+            <h1 class="text-2xl font-bold text-white mb-2">Sidebar buttons</h1>
+            <p class="text-zinc-400 text-sm">Add custom quick links next to the dashboard button (for example PhpMyAdmin).</p>
+        </div>
+        <div class="flex-1 space-y-6">
+            <div class="space-y-3">
+                <div class="flex items-center justify-between">
+                    <label class="block text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                        Buttons
+                    </label>
+                    <button id="add-sidebar-button" type="button"
+                        class="px-3 py-2 bg-zinc-700 hover:bg-zinc-600 text-white text-xs rounded-lg transition-colors duration-200">
+                        Add Button
+                    </button>
+                </div>
+
+                <div id="sidebar-buttons-list" class="space-y-4"></div>
+                <p class="text-xs text-zinc-500">Use absolute URLs or relative paths like <code>/admin</code>. Leave empty entries will be ignored.</p>
+            </div>
+        </div>
+    </form>
+
+    <script>
+        (() => {
+            const buttonsList = document.getElementById('sidebar-buttons-list');
+            const addButton = document.getElementById('add-sidebar-button');
+            let buttons = @json(old('sidebar_buttons', $configuredButtons));
+
+            const escapeHtml = (value) => {
+                const div = document.createElement('div');
+                div.textContent = value;
+                return div.innerHTML;
+            };
+
+            const normalizeButton = (button) => ({
+                label: button && typeof button.label === 'string' ? button.label : '',
+                url: button && typeof button.url === 'string' ? button.url : '',
+                newTab: button && (button.newTab === true || button.newTab === 1 || button.newTab === '1'),
+            });
+
+            const render = () => {
+                if (!Array.isArray(buttons)) {
+                    buttons = [];
+                }
+
+                buttons = buttons.map(normalizeButton);
+
+                if (buttons.length === 0) {
+                    buttons.push({
+                        label: '',
+                        url: '',
+                        newTab: false,
+                    });
+                }
+
+                buttonsList.innerHTML = buttons.map((button, index) => `
+                    <div class="p-4 bg-zinc-800/40 border border-zinc-700 rounded-xl space-y-3" data-index="${index}">
+                        <div class="flex items-center justify-between gap-3">
+                            <h3 class="text-sm text-zinc-200 font-medium">Button #${index + 1}</h3>
+                            <button type="button" class="remove-sidebar-button px-2 py-1 text-xs bg-red-900/30 border border-red-700 text-red-300 rounded-lg hover:bg-red-800/40 disabled:opacity-50 disabled:cursor-not-allowed" data-index="${index}" ${buttons.length === 1 ? 'disabled' : ''}>
+                                Remove
+                            </button>
+                        </div>
+                        <input
+                            type="text"
+                            name="sidebar_buttons[${index}][label]"
+                            class="sidebar-button-label w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
+                            placeholder="Label (e.g. PhpMyAdmin)"
+                            value="${escapeHtml(button.label)}"
+                        />
+                        <input
+                            type="text"
+                            name="sidebar_buttons[${index}][url]"
+                            class="sidebar-button-url w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
+                            placeholder="URL (e.g. /admin or https://example.com/phpmyadmin)"
+                            value="${escapeHtml(button.url)}"
+                        />
+                        <select
+                            name="sidebar_buttons[${index}][newTab]"
+                            class="sidebar-button-new-tab w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700 rounded-xl text-white placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200"
+                        >
+                            <option value="0" ${button.newTab ? '' : 'selected'}>Open in same tab</option>
+                            <option value="1" ${button.newTab ? 'selected' : ''}>Open in new tab</option>
+                        </select>
+                    </div>
+                `).join('');
+            };
+
+            addButton.addEventListener('click', () => {
+                buttons.push({
+                    label: '',
+                    url: '',
+                    newTab: false,
+                });
+                render();
+            });
+
+            buttonsList.addEventListener('click', (event) => {
+                const target = event.target;
+                if (!(target instanceof HTMLElement) || !target.classList.contains('remove-sidebar-button')) {
+                    return;
+                }
+
+                const index = Number(target.dataset.index);
+                if (Number.isNaN(index)) {
+                    return;
+                }
+
+                buttons.splice(index, 1);
+                render();
+            });
+
+            const handleFieldChange = (event) => {
+                const target = event.target;
+                if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) {
+                    return;
+                }
+
+                const wrapper = target.closest('[data-index]');
+                if (!(wrapper instanceof HTMLElement)) {
+                    return;
+                }
+
+                const index = Number(wrapper.dataset.index);
+                if (Number.isNaN(index) || !buttons[index]) {
+                    return;
+                }
+
+                if (target.classList.contains('sidebar-button-label')) {
+                    buttons[index].label = target.value;
+                }
+
+                if (target.classList.contains('sidebar-button-url')) {
+                    buttons[index].url = target.value;
+                }
+
+                if (target.classList.contains('sidebar-button-new-tab')) {
+                    buttons[index].newTab = target.value === '1';
+                }
+            };
+
+            buttonsList.addEventListener('input', handleFieldChange);
+            buttonsList.addEventListener('change', handleFieldChange);
+            render();
+        })();
+    </script>
+@endsection

--- a/resources/views/components/designify/sidebar.blade.php
+++ b/resources/views/components/designify/sidebar.blade.php
@@ -30,6 +30,11 @@
          icon="fa-solid fa-triangle-exclamation"
          label="Error Pages"
          :active="str_starts_with(Route::currentRouteName(),'admin.designify.errors')" />
+      <x-designify.tab-button
+         :route="route('admin.designify.sidebar-buttons')"
+         icon="fa-solid fa-link"
+         label="Sidebar Buttons"
+         :active="str_starts_with(Route::currentRouteName(),'admin.designify.sidebar-buttons')" />
       @include('partials.admin.designify.save')
    </div>
    <div class="flex-1 overflow-y-auto mt-2 pr-1 text-white p-1">

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -261,5 +261,7 @@ Route::group(['prefix' => 'designify'], function () {
     Route::patch('/site', [Admin\Designify\SiteController::class, 'update']);
     Route::get('/errors', [Admin\Designify\ErrorPagesController::class, 'index'])->name('admin.designify.errors');
     Route::patch('/errors', [Admin\Designify\ErrorPagesController::class, 'update']);
+    Route::get('/sidebar-buttons', [Admin\Designify\SidebarButtonsController::class, 'index'])->name('admin.designify.sidebar-buttons');
+    Route::patch('/sidebar-buttons', [Admin\Designify\SidebarButtonsController::class, 'update']);
     Route::match(['get', 'post', 'patch'], '/errors/preview/{code}', [Admin\Designify\ErrorPagesController::class, 'preview'])->name('admin.designify.errors.preview');
 });


### PR DESCRIPTION
 This adds a configurable sidebar button system in Designify so admins can create buttons which redirect to a link (for example external tools like PhpMyAdmin) directly in the user sidebar.
  This was implemented based on the request in issue #229

  - Added new Designify route + page (/panel/designify/sidebar-buttons) next to Error Pages.
  - Created SidebarButtonsController + SidebarButtonsSettingsFormRequest to validate and persist button configs.
  - Stored buttons in settings::designify:sidebarButtons (JSON).
  - Extended DesignifyServiceProvider + DesignifyComposer to load/normalize buttons into ReviactylConfiguration.
  - Extended Reviactyl frontend state types for sidebarButtons.
  - Updated dashboard Sidebar.tsx to render configured buttons (with optional new-tab behavior) under the account/activity section.                                                                                                      

                                                                                                                                                                                                                       