### PR TITLE
fix: use internalId instead of uuid for admin server edit URL

### DIFF
--- a/resources/scripts/components/server/TopServerDetails.tsx
+++ b/resources/scripts/components/server/TopServerDetails.tsx
@@ -53,7 +53,7 @@ const TopServerDetails = () => {
     const connected = ServerContext.useStoreState((state) => state.socket.connected);
     const instance = ServerContext.useStoreState((state) => state.socket.instance);
     const limits = ServerContext.useStoreState((state) => state.server.data!.limits);
-    const serverId = ServerContext.useStoreState((state) => state.server.data?.uuid);
+    const serverId = ServerContext.useStoreState((state) => state.server.data?.internalId);
     const rootAdmin = useStoreState((state) => state.user.data!.rootAdmin);
 
     const textLimits = useMemo(


### PR DESCRIPTION
Noticed the admin view button for servers were using uuid, but admin panel used id.