### PR TITLE
feat: Add Admin API Impersonation

### DIFF
--- a/app/Filament/Resources/Api/ApiKeyResource.php
+++ b/app/Filament/Resources/Api/ApiKeyResource.php
@@ -97,7 +97,13 @@ class ApiKeyResource extends Resource
             ->columns([
                 TextColumn::make('key')
                     ->label(trans('admin/api.key'))
-                    ->state(fn (ApiKey $key) => $key->identifier . decrypt($key->token))
+                    ->state(function (ApiKey $key) {
+                        try {
+                            return $key->identifier . decrypt($key->token);
+                        } catch (\Illuminate\Contracts\Encryption\DecryptException $e) {
+                            return $key->identifier . '(encrypted with old key)';
+                        }
+                    })
                     ->copyable(),
 
                 TextColumn::make('memo')

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -31,6 +31,7 @@ use Illuminate\Foundation\Http\Middleware\ValidatePostSize;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use App\Http\Middleware\Api\Daemon\DaemonAuthenticate;
 use App\Http\Middleware\Api\Client\RequireClientApiKey;
+use App\Http\Middleware\Api\Client\AuthenticateImpersonation;
 use App\Http\Middleware\RequireTwoFactorAuthentication;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use App\Http\Middleware\Api\Client\SubstituteClientBindings;
@@ -85,6 +86,7 @@ class Kernel extends HttpKernel
         ],
         'client-api' => [
             SubstituteClientBindings::class,
+            AuthenticateImpersonation::class,
             RequireClientApiKey::class,
         ],
         'daemon' => [

--- a/app/Http/Middleware/Api/Client/AuthenticateImpersonation.php
+++ b/app/Http/Middleware/Api/Client/AuthenticateImpersonation.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Middleware\Api\Client;
+
+use App\Models\ApiKey;
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class AuthenticateImpersonation
+{
+    public const IMPERSONATING_USER_ATTRIBUTE = 'impersonating_user';
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        /** @var \App\Models\User|null $caller */
+        $caller = $request->user();
+
+        if (!$caller) {
+            return $next($request);
+        }
+
+        $token = $caller->currentAccessToken();
+
+        if (!($token instanceof ApiKey) || $token->key_type !== ApiKey::TYPE_APPLICATION) {
+            return $next($request);
+        }
+
+        // Application API keys MUST specify which user they are acting as.
+        $executionUserId = $request->header('X-Execution-User');
+        if (empty($executionUserId)) {
+            throw new BadRequestHttpException(
+                'Application API keys must include the X-Execution-User header to access Client API endpoints.'
+            );
+        }
+
+        // Only root admins are permitted to impersonate users.
+        if (!$caller->root_admin) {
+            throw new AccessDeniedHttpException(
+                'You do not have permission to perform user impersonation.'
+            );
+        }
+
+        // Resolve the target user by integer ID or UUID.
+        $targetUser = User::query()
+            ->where(is_numeric($executionUserId) ? 'id' : 'uuid', $executionUserId)
+            ->first();
+
+        if (!$targetUser) {
+            throw new NotFoundHttpException(
+                'The user specified in X-Execution-User could not be found.'
+            );
+        }
+
+        // Preserve the original admin for auditing.
+        $request->attributes->set(self::IMPERSONATING_USER_ATTRIBUTE, $caller);
+
+        $request->setUserResolver(fn () => $targetUser);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/Api/Client/AuthenticateImpersonation.php
+++ b/app/Http/Middleware/Api/Client/AuthenticateImpersonation.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware\Api\Client;
 
 use App\Models\ApiKey;
 use App\Models\User;
+use App\Services\Acl\Api\AdminAcl;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -41,6 +42,20 @@ class AuthenticateImpersonation
         if (!$caller->root_admin) {
             throw new AccessDeniedHttpException(
                 'You do not have permission to perform user impersonation.'
+            );
+        }
+
+        // The application API key must have impersonation permission enabled.
+        if (!AdminAcl::check($token, AdminAcl::RESOURCE_IMPERSONATION, AdminAcl::READ)) {
+            throw new AccessDeniedHttpException(
+                'This API key does not have permission to perform user impersonation.'
+            );
+        }
+
+        // Read-only impersonation keys may not perform write operations.
+        if (!AdminAcl::check($token, AdminAcl::RESOURCE_IMPERSONATION, AdminAcl::WRITE) && !$request->isMethodSafe()) {
+            throw new AccessDeniedHttpException(
+                'This API key only has read-only impersonation permission and cannot perform write operations.'
             );
         }
 

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -116,6 +116,7 @@ class ApiKey extends Model implements HasAbilities
         'r_' . AdminAcl::RESOURCE_NESTS => 'int',
         'r_' . AdminAcl::RESOURCE_NODES => 'int',
         'r_' . AdminAcl::RESOURCE_SERVERS => 'int',
+        'r_' . AdminAcl::RESOURCE_IMPERSONATION => 'int',
     ];
 
     /**
@@ -158,6 +159,7 @@ class ApiKey extends Model implements HasAbilities
         'r_' . AdminAcl::RESOURCE_NESTS => 'integer|min:0|max:3',
         'r_' . AdminAcl::RESOURCE_NODES => 'integer|min:0|max:3',
         'r_' . AdminAcl::RESOURCE_SERVERS => 'integer|min:0|max:3',
+        'r_' . AdminAcl::RESOURCE_IMPERSONATION => 'integer|min:0|max:3',
     ];
 
     public function can($ability)

--- a/app/Services/Acl/Api/AdminAcl.php
+++ b/app/Services/Acl/Api/AdminAcl.php
@@ -33,6 +33,7 @@ class AdminAcl
     public const RESOURCE_EGGS = 'eggs';
     public const RESOURCE_DATABASE_HOSTS = 'database_hosts';
     public const RESOURCE_SERVER_DATABASES = 'server_databases';
+    public const RESOURCE_IMPERSONATION = 'impersonation';
 
     /**
      * Determine if an API key has permission to perform a specific read/write operation.

--- a/database/migrations/2026_03_11_000001_add_r_impersonation_to_api_keys_table.php
+++ b/database/migrations/2026_03_11_000001_add_r_impersonation_to_api_keys_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('api_keys', function (Blueprint $table) {
+            $table->unsignedTinyInteger('r_impersonation')->default(0)->after('r_server_databases');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('api_keys', function (Blueprint $table) {
+            $table->dropColumn('r_impersonation');
+        });
+    }
+};


### PR DESCRIPTION
The goal is to close #180. 

After thinking for a while, I decided that using an application API key for impersonation should be the same as using a client API key; however, the target user's ID or UUID must be included in the X-Execution-User header. This lets the system know the user you want to impersonate, and all actions are carried out using that user's access and permissions. Impersonation won't happen, and access will be blocked without the header. Using the other apis, administrators can still change things that users cannot.