### PR TITLE
fix: status page patch

### DIFF
--- a/app/Http/Controllers/Api/Public/ServerStatusController.php
+++ b/app/Http/Controllers/Api/Public/ServerStatusController.php
@@ -51,7 +51,7 @@ class ServerStatusController extends Controller
              $details = $this->repository->setServer($serverModel)->getDetails();
              $response['status'] = $details['state'] ?? 'offline';
              $response['utilization'] = $details['utilization'] ?? $response['utilization'];
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $response['status'] = 'offline';
         }
         

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -61,12 +61,12 @@ class RouteServiceProvider extends ServiceProvider
                     ->prefix('/api/client')
                     ->scopeBindings()
                     ->group(base_path('routes/api-client.php'));
-
-                Route::middleware(['api', 'throttle:api.client']) // reusing client throttle or create new one
-                    ->prefix('/api/public')
-                    ->scopeBindings()
-                    ->group(base_path('routes/api-public.php'));
             });
+
+            Route::middleware(['throttle:api.client'])
+                ->prefix('/api/public')
+                ->scopeBindings()
+                ->group(base_path('routes/api-public.php'));
 
             Route::middleware('daemon')
                 ->prefix('/api/remote')

--- a/app/Repositories/Wings/DaemonServerRepository.php
+++ b/app/Repositories/Wings/DaemonServerRepository.php
@@ -31,7 +31,7 @@ class DaemonServerRepository extends DaemonRepository
             throw new DaemonConnectionException($exception, false);
         }
 
-        return json_decode($response->getBody()->__toString(), true);
+        return json_decode($response->getBody()->__toString(), true) ?? [];
     }
 
     /**


### PR DESCRIPTION
When testing, I found the public status page had 2 main issues:

1. Offline servers would throw 500
2. **Public** status page required a valid bearer token