### PR TITLE
fix: use panel language by default, make not required, add geolocate

### DIFF
--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Users\Schemas;
 
+use App\Contracts\Repository\SettingsRepositoryInterface;
 use App\Models\User;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -46,9 +47,12 @@ class UserForm
                             ->maxLength(191),
                         Select::make('language')
                             ->label(trans('admin/user.details.language'))
-                            ->options((new User())->getAvailableLanguages(true))
-                            ->default('en')
-                            ->required(),
+                            ->options(array_merge(
+                                ['geo' => trans('admin/user.details.geolocate')],
+                                (new User())->getAvailableLanguages(true)
+                            ))
+                            ->default(fn () => app(SettingsRepositoryInterface::class)->get('settings::app:locale', 'en'))
+                            ->dehydrateStateUsing(fn ($state) => $state ?: app(SettingsRepositoryInterface::class)->get('settings::app:locale', 'en')),
                     ])
                     ->columns(2)
                     ->columnSpan(6),

--- a/app/Http/Middleware/LanguageMiddleware.php
+++ b/app/Http/Middleware/LanguageMiddleware.php
@@ -29,7 +29,12 @@ class LanguageMiddleware
         $user = $request->user();
 
         if ($user !== null) {
-            $locale = $user->language;
+            if ($user->language === 'geo') {
+                $defaultLocale = $this->settings->get('settings::app:locale', config('app.locale', 'en'));
+                $locale = $this->resolveGeoLocale($request, $defaultLocale);
+            } else {
+                $locale = $user->language;
+            }
         } else {
             $defaultLocale = $this->settings->get('settings::app:locale', config('app.locale', 'en'));
             $geolocateEnabled = (bool) $this->settings->get('settings::app:locale:geolocate', false);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -206,7 +206,7 @@ class User extends Model implements
     {
         $rules = parent::getRules();
 
-        $rules['language'][] = new In(array_keys((new self())->getAvailableLanguages()));
+        $rules['language'][] = new In([...array_keys((new self())->getAvailableLanguages()), 'geo']);
         $rules['username'][] = new Username();
 
         return $rules;

--- a/resources/lang/en/admin/user.php
+++ b/resources/lang/en/admin/user.php
@@ -18,6 +18,7 @@ return [
         'first_name' => 'First Name',
         'last_name' => 'Last Name',
         'language' => 'Language',
+        'geolocate' => 'Geolocate (Automatic)',
         'password' => 'Password',
         'password_confirmation' => 'Confirm Password',
         'root_admin' => 'Root Administrator',

--- a/resources/scripts/reviactyl/ui/LanguageSwitcher.tsx
+++ b/resources/scripts/reviactyl/ui/LanguageSwitcher.tsx
@@ -15,9 +15,12 @@ interface LanguageInfo {
 const LanguageSwitcher = () => {
     const { t } = useTranslation('dashboard/account');
     const user = useStoreState((state: ApplicationStore) => state.user.data);
+    const serverLocale = useStoreState((state: any) => state.settings.data?.locale || 'en');
     const setUserData = useStoreActions((actions: any) => actions.user.setUserData);
     const [languages, setLanguages] = useState<Record<string, LanguageInfo>>({});
-    const [currentLang, setCurrentLang] = useState(user?.language || i18n.language);
+    const [currentLang, setCurrentLang] = useState(
+        user?.language && user.language !== 'geo' ? user.language : serverLocale
+    );
 
     useEffect(() => {
         fetch('/locales/list.json')
@@ -67,7 +70,7 @@ export const LocaleLoader = () => {
     // via GeoIP and stored in SiteConfiguration), not hard-coded 'en'.
     const userLanguage = useStoreState((state: any) => state.user.data?.language);
     const serverLocale = useStoreState((state: any) => state.settings.data?.locale || 'en');
-    const effectiveLanguage = userLanguage || serverLocale;
+    const effectiveLanguage = userLanguage && userLanguage !== 'geo' ? userLanguage : serverLocale;
 
     useEffect(() => {
         if (effectiveLanguage && effectiveLanguage !== i18n.language) {

--- a/resources/scripts/reviactyl/ui/NavbarLanguageSwitcher.tsx
+++ b/resources/scripts/reviactyl/ui/NavbarLanguageSwitcher.tsx
@@ -66,9 +66,12 @@ const FlagIcon = styled.span`
 
 const NavbarLanguageSwitcher = () => {
     const user = useStoreState((state: ApplicationStore) => state.user.data);
+    const serverLocale = useStoreState((state: any) => state.settings.data?.locale || 'en');
     const setUserData = useStoreActions((actions: any) => actions.user.setUserData);
     const [languages, setLanguages] = useState<Record<string, LanguageInfo>>({});
-    const [currentLang, setCurrentLang] = useState(user?.language || i18n.language);
+    const [currentLang, setCurrentLang] = useState(
+        user?.language && user.language !== 'geo' ? user.language : serverLocale
+    );
     const [isOpen, setIsOpen] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
Fixes #260 

This pr makes the user creation ui autofill the language form with the panel's default language, makes it not required, and adds a geolocate option.