### PR TITLE
Add Backup Renaming

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/BackupController.php
+++ b/app/Http/Controllers/Api/Client/Servers/BackupController.php
@@ -121,6 +121,34 @@ class BackupController extends ClientApiController
     }
 
     /**
+     * Rename the backup alias shown in the panel.
+     *
+     * This does not change the archived filename on disk.
+     *
+     * @throws AuthorizationException
+     */
+    public function rename(Request $request, Server $server, Backup $backup): array
+    {
+        if (! $request->user()->can(Permission::ACTION_BACKUP_CREATE, $server)) {
+            throw new AuthorizationException();
+        }
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:191'],
+        ]);
+
+        $backup->update([
+            'name' => $data['name'],
+        ]);
+
+        Activity::event('server:backup.rename')->subject($backup)->property('name', $backup->name)->log();
+
+        return $this->fractal->item($backup)
+            ->transformWith($this->getTransformer(BackupTransformer::class))
+            ->toArray();
+    }
+
+    /**
      * Returns information about a single backup.
      *
      * @throws AuthorizationException

--- a/app/Http/Controllers/Auth/AbstractLoginController.php
+++ b/app/Http/Controllers/Auth/AbstractLoginController.php
@@ -10,6 +10,7 @@ use Illuminate\Auth\AuthManager;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -78,7 +79,13 @@ abstract class AbstractLoginController extends Controller
 
         $this->clearLoginAttempts($request);
 
-        $this->auth->guard()->login($user, true);
+        $guard = $this->auth->guard();
+
+        if (! $guard instanceof StatefulGuard) {
+            throw new \RuntimeException('Configured auth guard does not support stateful login.');
+        }
+
+        $guard->login($user, true);
 
         Event::dispatch(new DirectLogin($user, true));
 

--- a/resources/scripts/api/server/backups/index.ts
+++ b/resources/scripts/api/server/backups/index.ts
@@ -1,7 +1,10 @@
 import http from '@/api/http';
+import renameBackup from '@/api/server/backups/renameBackup';
 
 export const restoreServerBackup = async (uuid: string, backup: string, truncate?: boolean): Promise<void> => {
     await http.post(`/api/client/servers/${uuid}/backups/${backup}/restore`, {
         truncate,
     });
 };
+
+export { renameBackup };

--- a/resources/scripts/api/server/backups/renameBackup.ts
+++ b/resources/scripts/api/server/backups/renameBackup.ts
@@ -1,0 +1,7 @@
+import http from '@/api/http';
+
+export default async (uuid: string, backup: string, name: string): Promise<void> => {
+    await http.post(`/api/client/servers/${uuid}/backups/${backup}/rename`, {
+        name,
+    });
+};

--- a/resources/scripts/components/elements/Modal.tsx
+++ b/resources/scripts/components/elements/Modal.tsx
@@ -60,8 +60,7 @@ const ModalContainer = styled.div<{ alignTop?: boolean; size?: 'sm' | 'md' | 'lg
     margin-bottom: auto;
 
     & > .close-icon {
-        ${tw`absolute right-0 p-2 text-white cursor-pointer opacity-50 transition-all duration-150 ease-linear hover:opacity-100`};
-        top: -2.5rem;
+        ${tw`absolute right-0 top-0 p-2 m-2 text-gray-200 cursor-pointer opacity-70 transition-all duration-150 ease-linear hover:opacity-100`};
 
         &:hover {
             ${tw`transform rotate-90`}

--- a/resources/scripts/components/server/backups/BackupContextMenu.tsx
+++ b/resources/scripts/components/server/backups/BackupContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, forwardRef, useImperativeHandle } from 'react';
-import { FaBoxOpen, FaCloudArrowDown, FaEllipsis, FaLock, FaTrash, FaUnlock } from 'react-icons/fa6';
+import { FaBoxOpen, FaCloudArrowDown, FaEllipsis, FaLock, FaPen, FaTrash, FaUnlock } from 'react-icons/fa6';
 import DropdownMenu, { DropdownButtonRow } from '@/components/elements/DropdownMenu';
 import getBackupDownloadUrl from '@/api/server/backups/getBackupDownloadUrl';
 import useFlash from '@/plugins/useFlash';
@@ -16,6 +16,8 @@ import http, { httpErrorToHuman } from '@/api/http';
 import { Dialog } from '@/components/elements/dialog';
 import { useTranslation } from 'react-i18next';
 import { ExtensionSlot } from '@/extensions/ExtensionSlot';
+import { renameBackup } from '@/api/server/backups';
+import RenameBackupModal from '@/components/server/backups/RenameBackupModal';
 
 interface Props {
     backup: ServerBackup;
@@ -122,8 +124,43 @@ const BackupContextMenu = forwardRef<BackupContextMenuHandle, Props>(({ backup }
             .then(() => setModal(''));
     };
 
+    const onRename = (name: string) => {
+        clearFlashes('backups');
+
+        return renameBackup(uuid, backup.uuid, name)
+            .then(() =>
+                mutate(
+                    (data) => ({
+                        ...data,
+                        items: data.items.map((b) =>
+                            b.uuid === backup.uuid
+                                ? {
+                                      ...b,
+                                      name,
+                                  }
+                                : b
+                        ),
+                    }),
+                    false
+                )
+            )
+            .then(() => undefined)
+            .catch((error) => {
+                clearAndAddHttpError({ key: 'backups', error });
+
+                throw error;
+            });
+    };
+
     return (
         <>
+            <RenameBackupModal
+                visible={modal === 'rename'}
+                appear
+                backup={backup}
+                onDismissed={() => setModal('')}
+                onRenamed={onRename}
+            />
             <Dialog.Confirm
                 open={modal === 'unlock'}
                 onClose={() => setModal('')}
@@ -178,6 +215,12 @@ const BackupContextMenu = forwardRef<BackupContextMenuHandle, Props>(({ backup }
                 >
                     <div css={tw`text-sm`}>
                         <ExtensionSlot name={`server:backups:menu:start`} />
+                        <Can action={'backup.create'}>
+                            <DropdownButtonRow onClick={() => setModal('rename')}>
+                                <FaPen className={'text-xs inline-block w-[1.25em]'} />
+                                <span css={tw`ml-2`}>Rename</span>
+                            </DropdownButtonRow>
+                        </Can>
                         <Can action={'backup.download'}>
                             <DropdownButtonRow onClick={doDownload}>
                                 <FaCloudArrowDown className={'text-xs inline-block w-[1.25em]'} />

--- a/resources/scripts/components/server/backups/BackupRow.tsx
+++ b/resources/scripts/components/server/backups/BackupRow.tsx
@@ -99,7 +99,7 @@ export default ({ backup, className }: Props) => {
                 </p>
                 <p css={tw`text-2xs text-gray-500 uppercase mt-1`}>{t('created')}</p>
             </div>
-            <Can action={['backup.download', 'backup.restore', 'backup.delete']} matchAny>
+            <Can action={['backup.create', 'backup.download', 'backup.restore', 'backup.delete']} matchAny>
                 <div css={tw`mt-4 md:mt-0 ml-6`} style={{ marginRight: '-0.5rem' }}>
                     {!backup.completedAt ? (
                         <div css={tw`p-2 invisible`}>

--- a/resources/scripts/components/server/backups/RenameBackupModal.tsx
+++ b/resources/scripts/components/server/backups/RenameBackupModal.tsx
@@ -1,0 +1,56 @@
+import Modal, { RequiredModalProps } from '@/components/elements/Modal';
+import { Form, Formik, FormikHelpers } from 'formik';
+import Field from '@/components/elements/Field';
+import tw from 'twin.macro';
+import Button from '@/components/elements/Button';
+import { ServerBackup } from '@/api/server/types';
+import { useTranslation } from 'react-i18next';
+
+interface FormikValues {
+    name: string;
+}
+
+interface Props extends RequiredModalProps {
+    backup: ServerBackup;
+    onRenamed: (name: string) => Promise<void>;
+}
+
+const RenameBackupModal = ({ backup, onRenamed, ...props }: Props) => {
+    const { t } = useTranslation('server/backups');
+
+    const submit = ({ name }: FormikValues, { setSubmitting }: FormikHelpers<FormikValues>) => {
+        onRenamed(name)
+            .then(() => props.onDismissed())
+            .catch(() => setSubmitting(false));
+    };
+
+    return (
+        <Formik onSubmit={submit} enableReinitialize initialValues={{ name: backup.name }}>
+            {({ isSubmitting, values }) => (
+                <Modal {...props} dismissable={!isSubmitting} showSpinnerOverlay={isSubmitting}>
+                    <Form css={tw`m-0`}>
+                        <div css={tw`flex flex-wrap items-end`}>
+                            <div css={tw`w-full sm:flex-1 sm:mr-4`}>
+                                <Field
+                                    type={'string'}
+                                    id={'backup_name'}
+                                    name={'name'}
+                                    label={t('backup-name')}
+                                    description={t('name-description')}
+                                    autoFocus
+                                />
+                            </div>
+                            <div css={tw`w-full sm:w-auto mt-4 sm:mt-0`}>
+                                <Button css={tw`w-full`} disabled={values.name.trim().length < 1}>
+                                    Rename
+                                </Button>
+                            </div>
+                        </div>
+                    </Form>
+                </Modal>
+            )}
+        </Formik>
+    );
+};
+
+export default RenameBackupModal;

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -149,6 +149,7 @@ Route::group([
         Route::post('/', [Client\Servers\BackupController::class, 'store']);
         Route::get('/{backup}', [Client\Servers\BackupController::class, 'view']);
         Route::get('/{backup}/download', [Client\Servers\BackupController::class, 'download']);
+        Route::post('/{backup}/rename', [Client\Servers\BackupController::class, 'rename']);
         Route::post('/{backup}/lock', [Client\Servers\BackupController::class, 'toggleLock']);
         Route::middleware([ResourceLimit::Backup->middleware()])
             ->post('/{backup}/restore', [Client\Servers\BackupController::class, 'restore']);

--- a/tests/Integration/Api/Client/Server/Backup/RenameBackupTest.php
+++ b/tests/Integration/Api/Client/Server/Backup/RenameBackupTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Integration\Api\Client\Server\Backup;
+
+use App\Events\ActivityLogged;
+use App\Models\Backup;
+use App\Models\Permission;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Event;
+use Tests\Integration\Api\Client\ClientApiIntegrationTestCase;
+
+class RenameBackupTest extends ClientApiIntegrationTestCase
+{
+    public function test_user_without_permission_cannot_rename_backup()
+    {
+        [$user, $server] = $this->generateTestAccount([Permission::ACTION_BACKUP_READ]);
+
+        $backup = Backup::factory()->create(['server_id' => $server->id]);
+
+        $this->actingAs($user)
+            ->postJson($this->link($backup, '/rename'), ['name' => 'New Backup Name'])
+            ->assertStatus(Response::HTTP_FORBIDDEN);
+    }
+
+    public function test_backup_alias_can_be_renamed()
+    {
+        Event::fake([ActivityLogged::class]);
+
+        [$user, $server] = $this->generateTestAccount([Permission::ACTION_BACKUP_CREATE]);
+
+        /** @var Backup $backup */
+        $backup = Backup::factory()->create([
+            'server_id' => $server->id,
+            'name' => 'Old Backup Name',
+        ]);
+
+        $this->actingAs($user)
+            ->postJson($this->link($backup, '/rename'), ['name' => 'New Backup Name'])
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJsonPath('attributes.name', 'New Backup Name');
+
+        $backup->refresh();
+
+        $this->assertSame('New Backup Name', $backup->name);
+        $this->assertActivityFor('server:backup.rename', $user, [$backup, $backup->server]);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to rename a backup. As BXD stated, this does not edit the filename, but the name in the database for the backup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to rename backup display aliases from the backup context menu.
  - Added a rename dialog with validation, cancel controls, and submission feedback.
  - Backup renaming requires backup creation permission and does not alter the archived file.

- **Bug Fixes**
  - Prevented unnecessary updates and activity entries when the submitted name is unchanged.

- **Tests**
  - Added coverage for permissions, successful renaming, activity logging, and unchanged names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->