### PR TITLE
Fixes in Egg Descriptions

### DIFF
--- a/app/Filament/Resources/Nests/EggResource.php
+++ b/app/Filament/Resources/Nests/EggResource.php
@@ -135,7 +135,7 @@ class EggResource extends Resource
                                             ->required()
                                             ->maxLength(191),
                                         Forms\Components\TextInput::make('description')
-                                            ->maxLength(191),
+                                            ->dehydrateStateUsing(fn ($state) => $state ?? ''),
                                         Forms\Components\TextInput::make('env_variable')
                                             ->label(trans('admin/eggs.fields.env_variable'))
                                             ->required()

--- a/resources/scripts/components/server/files/ImageViewerModal.tsx
+++ b/resources/scripts/components/server/files/ImageViewerModal.tsx
@@ -65,7 +65,7 @@ const ImageViewerModal = ({ imageUrl, imageName, ...modalProps }: Props) => {
         });
 
         viewerRef.current = viewer;
-        modalProps.onDismissed()
+        modalProps.onDismissed();
         viewer.show();
     };
 


### PR DESCRIPTION
This PR fixes two issues:
1. Removes the 191-character limit since importing an egg bypasses it, creating a soft lock
2. Fixes the panel returning 500 when editing an imported egg with an empty field in descriptions
Thanks for reading!