### PR TITLE
Fix Database Creation

### DIFF
--- a/app/Filament/Resources/DatabaseHost/Pages/CreateDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHost/Pages/CreateDatabaseHost.php
@@ -6,10 +6,18 @@ use App\Filament\Resources\DatabaseHost\DatabaseHostResource;
 use App\Services\Activity\ActivityLogService;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
 
 class CreateDatabaseHost extends CreateRecord
 {
     protected static string $resource = DatabaseHostResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['password'] = Crypt::encrypt($data['password']);
+
+        return $data;
+    }
 
     protected function handleRecordCreation(array $data): Model
     {

--- a/app/Filament/Resources/DatabaseHost/Pages/EditDatabaseHost.php
+++ b/app/Filament/Resources/DatabaseHost/Pages/EditDatabaseHost.php
@@ -9,10 +9,22 @@ use Filament\Actions;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
 
 class EditDatabaseHost extends EditRecord
 {
     protected static string $resource = DatabaseHostResource::class;
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        if (filled($data['password'] ?? null)) {
+            $data['password'] = Crypt::encrypt($data['password']);
+        } else {
+            unset($data['password']);
+        }
+
+        return $data;
+    }
 
     protected function handleRecordUpdate(Model $record, array $data): Model
     {

--- a/database/migrations/2026_06_06_000000_encrypt_plaintext_database_host_passwords.php
+++ b/database/migrations/2026_06_06_000000_encrypt_plaintext_database_host_passwords.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('database_hosts')
+            ->select(['id', 'password'])
+            ->orderBy('id')
+            ->each(function (object $host): void {
+                if ($host->password === null || $host->password === '') {
+                    return;
+                }
+
+                try {
+                    Crypt::decrypt($host->password);
+
+                    return; 
+                } catch (DecryptException) {
+                    
+                }
+
+                DB::table('database_hosts')
+                    ->where('id', $host->id)
+                    ->update(['password' => Crypt::encrypt($host->password)]);
+            });
+    }
+
+    public function down(): void
+    {
+        // no-op
+    }
+};

--- a/tests/Integration/Admin/DatabaseHostEncryptionTest.php
+++ b/tests/Integration/Admin/DatabaseHostEncryptionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Integration\Admin;
+
+use App\Filament\Resources\DatabaseHost\Pages\CreateDatabaseHost;
+use App\Filament\Resources\DatabaseHost\Pages\EditDatabaseHost;
+use App\Models\DatabaseHost;
+use App\Models\User;
+use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\Integration\IntegrationTestCase;
+
+class DatabaseHostEncryptionTest extends IntegrationTestCase
+{
+    use RefreshDatabase;
+
+    private function actingAsAdmin(): void
+    {
+        $this->actingAs(User::factory()->create(['root_admin' => 1]));
+    }
+
+    public function test_creating_host_via_admin_stores_encrypted_password(): void
+    {
+        $this->actingAsAdmin();
+
+        Livewire::test(CreateDatabaseHost::class)
+            ->fillForm([
+                'name' => 'test-host',
+                'host' => '127.0.0.1',
+                'port' => 3306,
+                'username' => 'test_user',
+                'password' => 'TestPassword123!',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $host = DatabaseHost::query()->where('name', 'test-host')->firstOrFail();
+
+        $this->assertNotSame('TestPassword123!', $host->getRawOriginal('password'));
+        $this->assertSame('TestPassword123!', app(Encrypter::class)->decrypt($host->password));
+    }
+
+    public function test_editing_host_with_new_password_stores_encrypted(): void
+    {
+        $this->actingAsAdmin();
+
+        $host = DatabaseHost::factory()->create([
+            'password' => app(Encrypter::class)->encrypt('OldPassword1!'),
+        ]);
+
+        Livewire::test(EditDatabaseHost::class, ['record' => $host->getKey()])
+            ->fillForm(['password' => 'NewPassword2!'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $host->refresh();
+
+        $this->assertSame('NewPassword2!', app(Encrypter::class)->decrypt($host->password));
+    }
+
+    public function test_editing_host_without_password_keeps_existing(): void
+    {
+        $this->actingAsAdmin();
+
+        $host = DatabaseHost::factory()->create([
+            'password' => app(Encrypter::class)->encrypt('KeepThisPass1!'),
+        ]);
+
+        Livewire::test(EditDatabaseHost::class, ['record' => $host->getKey()])
+            ->fillForm(['name' => 'renamed-host'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $host->refresh();
+
+        $this->assertSame('renamed-host', $host->name);
+        $this->assertSame('KeepThisPass1!', app(Encrypter::class)->decrypt($host->password));
+    }
+}

--- a/tests/Integration/Admin/DatabaseHostPasswordMigrationTest.php
+++ b/tests/Integration/Admin/DatabaseHostPasswordMigrationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Integration\Admin;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Tests\Integration\IntegrationTestCase;
+
+class DatabaseHostPasswordMigrationTest extends IntegrationTestCase
+{
+    use RefreshDatabase;
+
+    private function runMigration(): void
+    {
+        $migration = require base_path('database/migrations/2026_06_06_000000_encrypt_plaintext_database_host_passwords.php');
+        $migration->up();
+    }
+
+    private function insertHost(string $name, string $password): int
+    {
+        return DB::table('database_hosts')->insertGetId([
+            'name' => $name,
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'username' => 'user',
+            'password' => $password,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function test_migration_encrypts_plaintext_and_leaves_encrypted_untouched(): void
+    {
+        $plainId = $this->insertHost('plain', 'PlainPass1!');
+
+        $encryptedValue = Crypt::encrypt('EncryptedPass2!');
+        $encId = $this->insertHost('encrypted', $encryptedValue);
+
+        $this->runMigration();
+
+        $healed = DB::table('database_hosts')->where('id', $plainId)->value('password');
+        $this->assertNotSame('PlainPass1!', $healed);
+        $this->assertSame('PlainPass1!', Crypt::decrypt($healed));
+
+        $untouched = DB::table('database_hosts')->where('id', $encId)->value('password');
+        $this->assertSame($encryptedValue, $untouched);
+        $this->assertSame('EncryptedPass2!', Crypt::decrypt($untouched));
+    }
+
+    public function test_migration_is_idempotent(): void
+    {
+        $plainId = $this->insertHost('plain', 'PlainPass1!');
+
+        $this->runMigration();
+        $afterFirst = DB::table('database_hosts')->where('id', $plainId)->value('password');
+
+        $this->runMigration();
+        $afterSecond = DB::table('database_hosts')->where('id', $plainId)->value('password');
+
+        $this->assertSame($afterFirst, $afterSecond);
+        $this->assertSame('PlainPass1!', Crypt::decrypt($afterSecond));
+    }
+}


### PR DESCRIPTION
This PR closes #390 and fixes an issue where creating a database host on a server would leave the database unencrypted, resulting in creating a database on a server with that database host linked failing. Feel free to remove any tests you find unnecessary or modify anything. Thanks for reading!