### PR TITLE
Fix Panel Installer Web GUI

### DIFF
--- a/app/Console/Commands/User/MakeUserCommand.php
+++ b/app/Console/Commands/User/MakeUserCommand.php
@@ -28,7 +28,10 @@ class MakeUserCommand extends Command
      */
     public function handle()
     {
-        $root_admin = $this->option('admin') ?? $this->confirm(trans('command/messages.user.ask_admin'));
+        $admin_option = $this->option('admin');
+        $root_admin = $admin_option !== null
+            ? filter_var($admin_option, FILTER_VALIDATE_BOOLEAN)
+            : $this->confirm(trans('command/messages.user.ask_admin'));
         $email = $this->option('email') ?? $this->ask(trans('command/messages.user.ask_email'));
         $username = $this->option('username') ?? $this->ask(trans('command/messages.user.ask_username'));
         $name_first = $this->option('name-first') ?? $this->ask(trans('command/messages.user.ask_name_first'));

--- a/app/Livewire/Installer.php
+++ b/app/Livewire/Installer.php
@@ -139,7 +139,7 @@ class Installer extends Component
                 '--name-first' => $this->user['name_first'],
                 '--name-last' => $this->user['name_last'],
                 '--password' => $this->user['password'],
-                '--admin' => 'Yes',
+                '--admin' => 1,
             ]);
 
             $this->step = 4;


### PR DESCRIPTION
This PR closes #377 and fixes an issue where creating the initial admin user from the panel's installer would fail, because it would pass yes to the database. This PR edits it to pass 1.