### PR TITLE
Extension Improvements

### DIFF
--- a/app/Filament/Resources/Extensions/Pages/ListExtensions.php
+++ b/app/Filament/Resources/Extensions/Pages/ListExtensions.php
@@ -21,7 +21,6 @@ class ListExtensions extends ListRecords
             Action::make('uploadInstall')
                 ->label(trans('admin/extensions.actions.upload'))
                 ->icon('heroicon-o-arrow-up-tray')
-                ->disabled() // TODO: not finished yet, so disable for now
                 ->form([
                     FileUpload::make('file')
                         ->label(trans('admin/extensions.columns.file'))
@@ -30,7 +29,8 @@ class ListExtensions extends ListRecords
                         ->storeFiles(false),
                 ])
                 ->action(function (array $data): void {
-                    $path = $this->resolveUploadPath(Arr::get($data, 'file'));
+                    $uploaded = Arr::get($data, 'file');
+                    $path = $this->resolveUploadPath($uploaded);
 
                     if ($path === null) {
                         Notification::make()
@@ -41,8 +41,11 @@ class ListExtensions extends ListRecords
                         return;
                     }
 
-                    // check if .rext
-                    if (strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'rext') {
+                    $clientName = $uploaded instanceof TemporaryUploadedFile
+                        ? $uploaded->getClientOriginalName()
+                        : basename($path);
+
+                    if (strtolower(pathinfo($clientName, PATHINFO_EXTENSION)) !== 'rext') {
                         Notification::make()
                             ->title(trans('admin/extensions.alerts.invalid_file_type'))
                             ->danger()
@@ -52,35 +55,33 @@ class ListExtensions extends ListRecords
                     }
 
                     // validation
+                    $needsCopy = strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'rext';
+                    $archivePath = $path;
+
+                    if ($needsCopy) {
+                        $archivePath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('rext_', true) . '.rext';
+                        copy($path, $archivePath);
+                    }
+
                     try {
-                        $zip = new \ZipArchive();
-
-                        if ($zip->open($path) !== true) {
-                            throw new \Exception('Invalid extension archive.');
-                        }
-
-                        if ($zip->locateName('extension.json') === false) {
-                            $zip->close();
-                            throw new \Exception('Invalid .rext package: extension.json missing.');
-                        }
-
-                        $zip->close();
-
                         /** @var ExtensionManager $manager */
                         $manager = app(ExtensionManager::class);
-                        $extension = $manager->installFromArchive($path, basename($path));
+                        $extension = $manager->installFromArchive($archivePath, $clientName);
 
                         Notification::make()
                             ->title(trans('admin/extensions.alerts.install_success', ['name' => $extension->name, 'version' => $extension->version]))
                             ->success()
                             ->send();
-
                     } catch (\Throwable $exception) {
                         Notification::make()
                             ->title(trans('admin/extensions.alerts.install_failed'))
                             ->body($exception->getMessage())
                             ->danger()
                             ->send();
+                    } finally {
+                        if ($needsCopy && is_file($archivePath)) {
+                            @unlink($archivePath);
+                        }
                     }
                 }),
         ];

--- a/app/Filament/Resources/Extensions/Pages/ListExtensions.php
+++ b/app/Filament/Resources/Extensions/Pages/ListExtensions.php
@@ -59,7 +59,7 @@ class ListExtensions extends ListRecords
                     $archivePath = $path;
 
                     if ($needsCopy) {
-                        $archivePath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('rext_', true) . '.rext';
+                        $archivePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.uniqid('rext_', true).'.rext';
                         copy($path, $archivePath);
                     }
 

--- a/app/Services/Extensions/ExtensionManager.php
+++ b/app/Services/Extensions/ExtensionManager.php
@@ -98,6 +98,7 @@ class ExtensionManager
         $record->api_version = $resolvedApiVersion;
         $record->target_version = Arr::get($manifest, 'target_version');
         $record->manifest = $manifest;
+        $record->enabled = true;
         $record->installed_at ??= now();
         $record->extension_updated_at = now();
         $record->save();
@@ -137,6 +138,8 @@ class ExtensionManager
         /** @var Extension $extension */
         $extension = Extension::query()->where('identifier', $identifier)->firstOrFail();
 
+        $this->removeOrphanedFilamentPages($identifier);
+
         if (File::exists($extension->install_path)) {
             File::deleteDirectory($extension->install_path);
         }
@@ -147,6 +150,26 @@ class ExtensionManager
         }
 
         $extension->delete();
+    }
+
+    private function removeOrphanedFilamentPages(string $identifier): void
+    {
+        $pagesPath = app_path('Filament/Pages');
+        if (! File::isDirectory($pagesPath)) {
+            return;
+        }
+
+        $needle = 'extensions/' . $identifier . '/';
+
+        foreach (File::files($pagesPath) as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            if (str_contains((string) File::get($file->getPathname()), $needle)) {
+                File::delete($file->getPathname());
+            }
+        }
     }
 
     /**

--- a/app/Services/Extensions/ExtensionManager.php
+++ b/app/Services/Extensions/ExtensionManager.php
@@ -89,6 +89,9 @@ class ExtensionManager
 
         /** @var Extension $record */
         $record = Extension::query()->firstOrNew(['identifier' => $identifier]);
+
+        $isNew = ! $record->exists;
+
         $record->name = (string) $manifest['name'];
         $record->version = (string) $manifest['version'];
         $record->description = Arr::get($manifest, 'description');
@@ -98,7 +101,11 @@ class ExtensionManager
         $record->api_version = $resolvedApiVersion;
         $record->target_version = Arr::get($manifest, 'target_version');
         $record->manifest = $manifest;
-        $record->enabled = true;
+
+        if ($isNew) {
+            $record->enabled = false;
+        }
+
         $record->installed_at ??= now();
         $record->extension_updated_at = now();
         $record->save();
@@ -159,7 +166,7 @@ class ExtensionManager
             return;
         }
 
-        $needle = 'extensions/' . $identifier . '/';
+        $needle = 'extensions/'.$identifier.'/';
 
         foreach (File::files($pagesPath) as $file) {
             if ($file->getExtension() !== 'php') {

--- a/resources/lang/en/admin/extensions.php
+++ b/resources/lang/en/admin/extensions.php
@@ -13,6 +13,7 @@ return [
         'enabled' => 'Enabled',
         'updated' => 'Updated',
         'manifest_json' => 'Manifest JSON',
+        'file' => 'Choose a .rext file to upload',
     ],
 
     'modals' => [


### PR DESCRIPTION
This PR adds the ability to import extensions via the button in the admin interface and adds a fix to the uninstall flow so that the panel fully removes any admin files installed by the extension. Finally, it makes extensions enabled by default when being imported, since you'd probably want to use the extension when you import it. Thanks!