### PR TITLE
Fix Geolocation Toggling

### DIFF
--- a/app/Http/Middleware/LanguageMiddleware.php
+++ b/app/Http/Middleware/LanguageMiddleware.php
@@ -39,7 +39,7 @@ class LanguageMiddleware
                 }
             } else {
                 $defaultLocale = $this->settings->get('settings::app:locale', $fallbackLocale);
-                $geolocateEnabled = (bool) $this->settings->get('settings::app:locale:geolocate', false);
+                $geolocateEnabled = filter_var($this->settings->get('settings::app:locale:geolocate', false), FILTER_VALIDATE_BOOLEAN);
 
                 if ($geolocateEnabled) {
                     $locale = $this->resolveGeoLocale($request, $defaultLocale);


### PR DESCRIPTION
This PR closes #380 and fixes geolocation by ensuring the server interprets it as a boolean rather than a string, so it doesn't return true every time.