### PR TITLE
Upload Status Dialog Fixes

### DIFF
--- a/resources/lang/en/server/files.php
+++ b/resources/lang/en/server/files.php
@@ -22,6 +22,7 @@ return [
     'file-mode-label' => 'File Mode',
     'new-location' => 'New location:',
     'cancel-uploads' => 'Cancel Uploads',
+    'close' => 'Close',
     'uploads-tooltip' => ':count files are uploading, click to view',
     'move-description' => 'Enter the new name and directory of this file or folder, relative to the current directory.',
     'update' => 'Update',

--- a/resources/scripts/components/server/files/FileManagerStatus.tsx
+++ b/resources/scripts/components/server/files/FileManagerStatus.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { ServerContext } from '@/state/server';
 import { XIcon } from '@heroicons/react/solid';
 import asDialog from '@/hoc/asDialog';
@@ -6,7 +6,6 @@ import { Dialog, DialogWrapperContext } from '@/reviactyl/elements/dialog';
 import { Button } from '@/reviactyl/components/button/index';
 import Tooltip from '@/reviactyl/elements/tooltip/Tooltip';
 import Code from '@/reviactyl/elements/Code';
-import { useSignal } from '@preact/signals-react';
 import { WithClassname } from '@/components/types';
 import { FaCloudArrowDown } from 'react-icons/fa6';
 import { useTranslation } from 'react-i18next';
@@ -78,7 +77,7 @@ const FileUploadListDialog = asDialog({})(FileUploadList);
 
 export default ({ className }: WithClassname) => {
     const { t } = useTranslation('server/files');
-    const open = useSignal(false);
+    const [open, setOpen] = useState(false);
 
     const count = ServerContext.useStoreState((state) => Object.keys(state.files.uploads).length);
     const progress = ServerContext.useStoreState((state) => ({
@@ -88,7 +87,7 @@ export default ({ className }: WithClassname) => {
 
     useEffect(() => {
         if (count === 0) {
-            open.value = false;
+            setOpen(false);
         }
     }, [count]);
 
@@ -101,14 +100,14 @@ export default ({ className }: WithClassname) => {
                             className ||
                             'flex items-center justify-center w-10 h-10 rounded-ui bg-gray-900 border border-gray-800 text-blue-300 hover:text-blue-100 hover:border-gray-600 transition-colors'
                         }
-                        onClick={() => (open.value = true)}
+                        onClick={() => setOpen(true)}
                     >
                         <Spinner progress={(progress.uploaded / progress.total) * 100} className={'w-8 h-8'} />
                         <FaCloudArrowDown className={'h-3 absolute mx-auto animate-pulse'} />
                     </button>
                 </Tooltip>
             )}
-            <FileUploadListDialog open={open.value} onClose={() => (open.value = false)} />
+            <FileUploadListDialog open={open && count > 0} onClose={() => setOpen(false)} />
         </>
     );
 };

--- a/resources/scripts/components/server/files/UploadButton.tsx
+++ b/resources/scripts/components/server/files/UploadButton.tsx
@@ -37,7 +37,7 @@ export default ({ className }: WithClassname & { compact?: boolean }) => {
 
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
     const directory = ServerContext.useStoreState((state) => state.files.directory);
-    const { clearFileUploads, removeFileUpload, pushFileUpload, setUploadProgress } = ServerContext.useStoreActions(
+    const { removeFileUpload, pushFileUpload, setUploadProgress } = ServerContext.useStoreActions(
         (actions) => actions.files
     );
 
@@ -115,9 +115,9 @@ export default ({ className }: WithClassname & { compact?: boolean }) => {
             });
 
             return () =>
-                getFileUploadUrl(uuid).then((url) =>
-                    axios
-                        .post(
+                getFileUploadUrl(uuid)
+                    .then((url) =>
+                        axios.post(
                             url,
                             { files: file },
                             {
@@ -127,16 +127,24 @@ export default ({ className }: WithClassname & { compact?: boolean }) => {
                                 onUploadProgress: (data) => onUploadProgress(data, file.name),
                             }
                         )
-                        .then(() => timeouts.current.push(setTimeout(() => removeFileUpload(file.name), 500)))
-                );
+                    )
+                    .then(() => timeouts.current.push(setTimeout(() => removeFileUpload(file.name), 500)))
+                    .catch((error) => {
+                        removeFileUpload(file.name);
+                        if (!axios.isCancel(error)) {
+                            throw error;
+                        }
+                    });
         });
 
-        Promise.all(uploads.map((fn) => fn()))
-            .then(() => mutate())
-            .catch((error) => {
-                clearFileUploads();
-                clearAndAddHttpError(error);
-            });
+        Promise.allSettled(uploads.map((fn) => fn())).then((results) => {
+            mutate();
+
+            const failure = results.find((result) => result.status === 'rejected');
+            if (failure) {
+                clearAndAddHttpError((failure as PromiseRejectedResult).reason);
+            }
+        });
     };
 
     // Keep ref in sync so the global drop handler can call the latest onFileSubmission


### PR DESCRIPTION
This PR addresses 2 fixes to the upload status dialog:

1. The close button does not have a translation key
2. The dialog becomes frozen once the upload finishes 