### PR TITLE
FIX WHEN ADDED NEW NODES: Add input validation and change status code for exceptions

### DIFF
--- a/app/Exceptions/Model/DataValidationException.php
+++ b/app/Exceptions/Model/DataValidationException.php
@@ -39,7 +39,7 @@ class DataValidationException extends PanelException implements HttpExceptionInt
      */
     public function getStatusCode(): int
     {
-        return 500;
+        return 422;
     }
 
     public function getHeaders(): array

--- a/app/Filament/Resources/Nodes/Schemas/CreateNodeForm.php
+++ b/app/Filament/Resources/Nodes/Schemas/CreateNodeForm.php
@@ -30,6 +30,7 @@ class CreateNodeForm
                                         ->label(trans('admin/node.fields.name.label'))
                                         ->required()
                                         ->maxLength(100)
+                                        ->regex('/^([\w .-]{1,100})$/')
                                         ->placeholder(trans('admin/node.fields.name.placeholder'))
                                         ->helperText(trans('admin/node.fields.name.helper'))
                                         ->columnSpan(1)

--- a/app/Filament/Resources/Nodes/Schemas/EditNodeForm.php
+++ b/app/Filament/Resources/Nodes/Schemas/EditNodeForm.php
@@ -240,6 +240,7 @@ class EditNodeForm
                                             ->label(trans('admin/node.fields.name.label'))
                                             ->required()
                                             ->maxLength(100)
+                                            ->regex('/^([\w .-]{1,100})$/')
                                             ->placeholder(trans('admin/node.fields.name.placeholder'))
                                             ->helperText(trans('admin/node.fields.name.helper'))
                                             ->columnSpanFull(),


### PR DESCRIPTION
Changed DataValidationException to return 422 instead of 500 allowing Filament to treat model validation failures as normal validation errors

Added the same node name regex validation to both the create node and edit node forms ensuring invalid names are caught before submission and stay consistent with backend validation