### PR TITLE
feat(ui): enhance monitoring dashboard and optimize data fetching

### DIFF
--- a/app/Filament/Pages/Monitoring.php
+++ b/app/Filament/Pages/Monitoring.php
@@ -29,9 +29,7 @@ class Monitoring extends Page
     #[On('nodeChanged')]
     public function updateSelectedNode(?int $nodeId = null): void
     {
-        if ($nodeId) {
-            $this->selectedNodeId = $nodeId;
-        }
+        $this->selectedNodeId = $nodeId;
     }
 
     public static function getNavigationLabel(): string
@@ -201,6 +199,72 @@ class Monitoring extends Page
                             ->content(number_format((float) ($data['memory']['swap_usage_percent'] ?? 0), 2).'%'),
                     ];
                 }),
+
+            Section::make(trans('admin/monitoring.details.partitions_section'))
+                ->icon('heroicon-o-server-stack')
+                ->schema([
+                    Placeholder::make('partitions')
+                        ->hiddenLabel()
+                        ->content(function () use ($data): HtmlString {
+                            $partitions = $data['disk']['partitions'] ?? [];
+
+                            if (empty($partitions)) {
+                                return new HtmlString('<span class="text-gray-400">'.e(trans('admin/monitoring.details.partitions_none')).'</span>');
+                            }
+
+                            $rows = '';
+                            foreach ($partitions as $partition) {
+                                $device = e((string) ($partition['device'] ?? '—'));
+                                $mount = e((string) ($partition['mountpoint'] ?? '—'));
+                                $filesystem = e((string) ($partition['filesystem'] ?? '—'));
+                                $used = $this->formatBytes((int) ($partition['used_bytes'] ?? 0));
+                                $total = $this->formatBytes((int) ($partition['total_bytes'] ?? 0));
+                                $pct = (float) ($partition['usage_percent'] ?? 0);
+                                $pctLabel = number_format($pct, 1).'%';
+                                $pctColor = $pct >= 80 ? '#ef4444' : ($pct >= 60 ? '#eab308' : '#22c55e');
+                                $pctWidth = min($pct, 100);
+
+                                $rows .= <<<HTML
+                                <tr style="border-bottom:1px solid rgba(255,255,255,0.05)">
+                                    <td style="padding:8px 12px;font-size:12px;color:#f1f5f9;font-family:monospace">{$device}</td>
+                                    <td style="padding:8px 12px;font-size:12px;color:#94a3b8;font-family:monospace">{$mount}</td>
+                                    <td style="padding:8px 12px;font-size:11px;color:#38bdf8;font-family:monospace">{$filesystem}</td>
+                                    <td style="padding:8px 12px;font-size:12px;color:#94a3b8;font-family:monospace">{$used} / {$total}</td>
+                                    <td style="padding:8px 12px;min-width:160px">
+                                        <div style="font-size:11px;color:#94a3b8;font-family:monospace;margin-bottom:4px">{$pctLabel}</div>
+                                        <div style="height:5px;width:100%;background:rgba(255,255,255,0.08);border-radius:9999px;overflow:hidden">
+                                            <div style="height:100%;width:{$pctWidth}%;background:{$pctColor};border-radius:9999px"></div>
+                                        </div>
+                                    </td>
+                                </tr>
+                                HTML;
+                            }
+
+                            $hDevice = e(trans('admin/monitoring.details.partitions_device'));
+                            $hMount = e(trans('admin/monitoring.details.partitions_mountpoint'));
+                            $hFs = e(trans('admin/monitoring.details.partitions_filesystem'));
+                            $hSize = e(trans('admin/monitoring.details.partitions_size'));
+                            $hUsage = e(trans('admin/monitoring.details.partitions_usage'));
+                            $thStyle = 'padding:8px 12px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:#64748b';
+
+                            return new HtmlString(<<<HTML
+                            <div style="overflow-x:auto;border-radius:8px">
+                                <table style="width:100%;border-collapse:collapse;text-align:left">
+                                    <thead>
+                                        <tr style="border-bottom:1px solid rgba(255,255,255,0.08)">
+                                            <th style="{$thStyle}">{$hDevice}</th>
+                                            <th style="{$thStyle}">{$hMount}</th>
+                                            <th style="{$thStyle}">{$hFs}</th>
+                                            <th style="{$thStyle}">{$hSize}</th>
+                                            <th style="{$thStyle}">{$hUsage}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>{$rows}</tbody>
+                                </table>
+                            </div>
+                            HTML);
+                        }),
+                ]),
 
             Section::make(trans('admin/monitoring.details.network_section'))
                 ->icon('heroicon-o-signal')

--- a/app/Filament/Resources/Nodes/Schemas/EditNodeForm.php
+++ b/app/Filament/Resources/Nodes/Schemas/EditNodeForm.php
@@ -33,6 +33,26 @@ class EditNodeForm
         $softwareVersionService = app(SoftwareVersionService::class);
         $isLatest = $softwareVersionService->isLatestPanel();
 
+        // Fetch node monitoring data at most once per request instead of once
+        // per TextEntry state/color closure.
+        $monitoring = null;
+        $getMonitoring = function ($record) use (&$monitoring): ?array {
+            if (! $record) {
+                return null;
+            }
+            if ($monitoring === null) {
+                try {
+                    $monitoring = app(DaemonMonitoringRepository::class)
+                        ->setNode($record)
+                        ->getSystemMonitoring();
+                } catch (\Throwable) {
+                    $monitoring = [];
+                }
+            }
+
+            return $monitoring ?: null;
+        };
+
         return $schema
             ->components([
                 Tabs::make(trans('admin/node.sections.tabs.title'))
@@ -118,103 +138,97 @@ class EditNodeForm
                                         TextEntry::make('cpu_usage')
                                             ->label(trans('admin/node.sections.overview.cpu-usage-label'))
                                             ->badge()
-                                            ->color(function ($record) {
-                                                try {
-                                                    $repository = app(DaemonMonitoringRepository::class);
-                                                    $data = $repository->setNode($record)->getSystemMonitoring();
+                                            ->color(function ($record) use ($getMonitoring) {
+                                                $data = $getMonitoring($record);
 
-                                                    $usage = (float) ($data['cpu']['usage_percent'] ?? 0);
-
-                                                    return match (true) {
-                                                        $usage >= 80 => 'danger',
-                                                        $usage >= 50 => 'warning',
-                                                        default => 'success',
-                                                    };
-                                                } catch (\Throwable $e) {
+                                                if (! $data) {
                                                     return 'gray';
                                                 }
+
+                                                $usage = (float) ($data['cpu']['usage_percent'] ?? 0);
+
+                                                return match (true) {
+                                                    $usage >= 80 => 'danger',
+                                                    $usage >= 50 => 'warning',
+                                                    default => 'success',
+                                                };
                                             })
-                                            ->state(function ($record) {
+                                            ->state(function ($record) use ($getMonitoring) {
                                                 if (! $record) {
                                                     return trans('admin/node.general.na');
                                                 }
 
-                                                try {
-                                                    $repository = app(DaemonMonitoringRepository::class);
-                                                    $data = $repository->setNode($record)->getSystemMonitoring();
+                                                $data = $getMonitoring($record);
 
-                                                    return number_format($data['cpu']['usage_percent'] ?? 0, 2).'%';
-                                                } catch (\Throwable $e) {
+                                                if (! $data) {
                                                     return trans('admin/node.general.unavailable');
                                                 }
+
+                                                return number_format($data['cpu']['usage_percent'] ?? 0, 2).'%';
                                             }),
 
                                         TextEntry::make('memory_usage')
                                             ->label(trans('admin/node.sections.overview.memory-usage-label'))
                                             ->badge()
-                                            ->color(function ($record) {
-                                                try {
-                                                    $repository = app(DaemonMonitoringRepository::class);
-                                                    $data = $repository->setNode($record)->getSystemMonitoring();
+                                            ->color(function ($record) use ($getMonitoring) {
+                                                $data = $getMonitoring($record);
 
-                                                    $usage = (float) ($data['memory']['usage_percent'] ?? 0);
-
-                                                    return match (true) {
-                                                        $usage >= 80 => 'danger',
-                                                        $usage >= 50 => 'warning',
-                                                        default => 'success',
-                                                    };
-                                                } catch (\Throwable $e) {
+                                                if (! $data) {
                                                     return 'gray';
                                                 }
+
+                                                $usage = (float) ($data['memory']['usage_percent'] ?? 0);
+
+                                                return match (true) {
+                                                    $usage >= 80 => 'danger',
+                                                    $usage >= 50 => 'warning',
+                                                    default => 'success',
+                                                };
                                             })
-                                            ->state(function ($record) {
+                                            ->state(function ($record) use ($getMonitoring) {
                                                 if (! $record) {
                                                     return trans('admin/node.general.na');
                                                 }
 
-                                                try {
-                                                    $repository = app(DaemonMonitoringRepository::class);
-                                                    $data = $repository->setNode($record)->getSystemMonitoring();
+                                                $data = $getMonitoring($record);
 
-                                                    return number_format($data['memory']['usage_percent'] ?? 0, 2).'%';
-                                                } catch (\Throwable $e) {
+                                                if (! $data) {
                                                     return trans('admin/node.general.unavailable');
                                                 }
+
+                                                return number_format($data['memory']['usage_percent'] ?? 0, 2).'%';
                                             }),
 
                                         TextEntry::make('disk_usage')
                                             ->label(trans('admin/node.sections.overview.disk-usage-label'))
                                             ->badge()
-                                            ->color(function ($record) {
-                                                try {
-                                                    $repository = app(DaemonMonitoringRepository::class);
-                                                    $data = $repository->setNode($record)->getSystemMonitoring();
+                                            ->color(function ($record) use ($getMonitoring) {
+                                                $data = $getMonitoring($record);
 
-                                                    $usage = (float) ($data['disk']['usage_percent'] ?? 0);
-
-                                                    return match (true) {
-                                                        $usage >= 80 => 'danger',
-                                                        $usage >= 50 => 'warning',
-                                                        default => 'success',
-                                                    };
-                                                } catch (\Throwable $e) {
+                                                if (! $data) {
                                                     return 'gray';
                                                 }
+
+                                                $usage = (float) ($data['disk']['usage_percent'] ?? 0);
+
+                                                return match (true) {
+                                                    $usage >= 80 => 'danger',
+                                                    $usage >= 50 => 'warning',
+                                                    default => 'success',
+                                                };
                                             })
-                                            ->state(function ($record) {
+                                            ->state(function ($record) use ($getMonitoring) {
                                                 if (! $record) {
                                                     return trans('admin/node.general.na');
                                                 }
 
-                                                try {
-                                                    $repository = app(DaemonMonitoringRepository::class);
-                                                    $data = $repository->setNode($record)->getSystemMonitoring();
+                                                $data = $getMonitoring($record);
 
-                                                    return number_format($data['disk']['usage_percent'] ?? 0, 2).'%';
-                                                } catch (\Throwable $e) {
+                                                if (! $data) {
                                                     return trans('admin/node.general.unavailable');
                                                 }
+
+                                                return number_format($data['disk']['usage_percent'] ?? 0, 2).'%';
                                             }),
 
                                         Actions::make([

--- a/app/Filament/Widgets/MonitoringWidget.php
+++ b/app/Filament/Widgets/MonitoringWidget.php
@@ -36,7 +36,7 @@ class MonitoringWidget extends BaseWidget
     #[On('nodeChanged')]
     public function updateNodeId(?int $nodeId = null): void
     {
-        if ($nodeId && $nodeId !== $this->selectedNodeId) {
+        if ($nodeId !== $this->selectedNodeId) {
             $this->selectedNodeId = $nodeId;
             $this->cpuHistory = [];
             $this->memoryHistory = [];
@@ -60,6 +60,7 @@ class MonitoringWidget extends BaseWidget
             $node = Node::findOrFail($this->selectedNodeId);
         } catch (ModelNotFoundException) {
             $this->selectedNodeId = null;
+            $this->dispatch('nodeInvalid');
 
             return $this->getErrorStats(trans('admin/monitoring.stats.error_node_gone'));
         }

--- a/app/Filament/Widgets/NodeSelectorWidget.php
+++ b/app/Filament/Widgets/NodeSelectorWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Models\Node;
 use Filament\Forms\Components\Select;
 use Filament\Schemas\Schema;
+use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
 
 class NodeSelectorWidget extends BaseWidget
@@ -39,6 +40,12 @@ class NodeSelectorWidget extends BaseWidget
         $this->dispatch('nodeChanged', nodeId: $this->nodeId);
     }
 
+    #[On('nodeInvalid')]
+    public function invalidateNode(): void
+    {
+        $this->nodeId = null;
+    }
+
     public function form(Schema $schema): Schema
     {
         return $schema->components([
@@ -46,8 +53,7 @@ class NodeSelectorWidget extends BaseWidget
                 ->label(trans('admin/monitoring.selector.label'))
                 ->placeholder(trans('admin/monitoring.selector.placeholder'))
                 ->options(Node::query()->orderBy('name')->pluck('name', 'id'))
-                ->live()
-                ->afterStateUpdated(fn ($state) => $this->dispatch('nodeChanged', nodeId: $state)),
+                ->live(),
         ]);
     }
 }

--- a/app/Filament/Widgets/ServersWidget.php
+++ b/app/Filament/Widgets/ServersWidget.php
@@ -28,7 +28,7 @@ class ServersWidget extends BaseWidget
     #[On('nodeChanged')]
     public function updateNodeId(?int $nodeId = null): void
     {
-        if ($nodeId && $nodeId !== $this->selectedNodeId) {
+        if ($nodeId !== $this->selectedNodeId) {
             $this->selectedNodeId = $nodeId;
         }
     }
@@ -226,6 +226,8 @@ class ServersWidget extends BaseWidget
         try {
             $node = Node::find($this->selectedNodeId);
             if (! $node) {
+                $this->dispatch('nodeInvalid');
+
                 return [];
             }
             $repository = app(DaemonServerStatusRepository::class);

--- a/resources/lang/en/admin/monitoring.php
+++ b/resources/lang/en/admin/monitoring.php
@@ -61,6 +61,14 @@ return [
         'swap_free' => 'Free',
         'swap_usage' => 'Usage',
 
+        'partitions_section' => 'Disk Partitions',
+        'partitions_none' => 'No partition data available.',
+        'partitions_device' => 'Device',
+        'partitions_mountpoint' => 'Mount Point',
+        'partitions_filesystem' => 'Filesystem',
+        'partitions_size' => 'Size',
+        'partitions_usage' => 'Usage',
+
         'network_section' => 'Network',
         'bytes_sent' => 'Bytes Sent',
         'bytes_recv' => 'Bytes Received',


### PR DESCRIPTION
Add a new disk partitions section to the monitoring page and improve the efficiency of node monitoring data retrieval in the node edit form by caching the repository results within the request lifecycle.

- Add disk partitions details section to Monitoring page
- Optimize `EditNodeForm` by fetching monitoring data once per request
- Implement `nodeInvalid` event to synchronize node selection across widgets when a node is no longer available
- Refactor node selection logic in `MonitoringPage` and widgets
- Add missing translation keys for disk partition information