### PR TITLE
Fix egg variable relationship

### DIFF
--- a/app/Models/EggVariable.php
+++ b/app/Models/EggVariable.php
@@ -5,8 +5,8 @@ namespace App\Models;
 use Carbon\CarbonImmutable;
 use Database\Factories\EggVariableFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * @property int $id
@@ -87,11 +87,11 @@ class EggVariable extends Model
     }
 
     /**
-     * @return HasOne<Egg, $this>
+     * @return BelongsTo<Egg, $this>
      */
-    public function egg(): HasOne
+    public function egg(): BelongsTo
     {
-        return $this->hasOne(Egg::class);
+        return $this->belongsTo(Egg::class);
     }
 
     /**

--- a/tests/Integration/Models/EggVariableTest.php
+++ b/tests/Integration/Models/EggVariableTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Integration\Models;
+
+use App\Models\EggVariable;
+use Tests\Integration\IntegrationTestCase;
+
+class EggVariableTest extends IntegrationTestCase
+{
+    public function test_egg_relationship(): void
+    {
+        $server = $this->createServerModel();
+        $variable = EggVariable::query()->where('egg_id', $server->egg_id)->firstOrFail();
+
+        $this->assertTrue($variable->egg->is($server->egg));
+    }
+}


### PR DESCRIPTION
This PR fixes a low-impact issue where accessing an egg variable’s `egg` relationship caused an unknown-column database error.