### PR TITLE
Disable reinstall when "Skip Egg Install Scripts" is enabled.

### DIFF
--- a/app/Exceptions/DisplayException.php
+++ b/app/Exceptions/DisplayException.php
@@ -52,7 +52,7 @@ class DisplayException extends PanelException implements HttpExceptionInterface
      */
     public function render(Request $request): JsonResponse|RedirectResponse
     {
-        if ($request->expectsJson()) {
+        if ($request->expectsJson() || $request->is('api/*')) {
             return response()->json(Handler::toArray($this), $this->getStatusCode(), $this->getHeaders());
         }
 

--- a/app/Filament/Resources/Servers/Schemas/EditServerForm.php
+++ b/app/Filament/Resources/Servers/Schemas/EditServerForm.php
@@ -245,7 +245,7 @@ class EditServerForm
                                                     Action::make('reinstall_server')
                                                         ->label(trans('admin/server.edit.actions.reinstall_server'))
                                                         ->color('danger')
-                                                        ->disabled(fn (?Server $record): bool => ! $record?->isInstalled())
+                                                        ->disabled(fn (?Server $record): bool => ! $record?->canBeReinstalled())
                                                         ->requiresConfirmation()
                                                         ->action(fn (Server $record) => self::reinstall($record)),
                                                 ]),

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -313,6 +313,19 @@ class Server extends Model implements Identifiable
     }
 
     /**
+     * A server that skips its egg's install script gains nothing from a reinstall. The one
+     * exception is a server sitting in a failed state, where that report is the way back out.
+     */
+    public function canBeReinstalled(): bool
+    {
+        return ! $this->skip_scripts || in_array($this->status, [
+            self::STATUS_INSTALLING,
+            self::STATUS_INSTALL_FAILED,
+            self::STATUS_REINSTALL_FAILED,
+        ], true);
+    }
+
+    /**
      * Gets the user who owns the server.
      *
      * @return BelongsTo<User, $this>

--- a/app/Services/Servers/ReinstallServerService.php
+++ b/app/Services/Servers/ReinstallServerService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Servers;
 
+use App\Exceptions\DisplayException;
 use App\Models\Server;
 use App\Repositories\Agent\DaemonServerRepository;
 use Illuminate\Database\ConnectionInterface;
@@ -20,9 +21,15 @@ class ReinstallServerService
      * Reinstall a server on the remote daemon.
      *
      * @throws \Throwable
+     * @throws DisplayException
      */
     public function handle(Server $server): Server
     {
+
+        if (! $server->canBeReinstalled()) {
+            throw new DisplayException(trans('admin/server.exceptions.skipping_install_script'));
+        }
+
         return $this->connection->transaction(function () use ($server) {
             $server->fill(['status' => Server::STATUS_INSTALLING])->save();
 

--- a/app/Transformers/Api/Application/ServerTransformer.php
+++ b/app/Transformers/Api/Application/ServerTransformer.php
@@ -86,6 +86,7 @@ class ServerTransformer extends BaseTransformer
                 // This field is deprecated, please use "status".
                 'installed' => $server->isInstalled() ? 1 : 0,
                 'environment' => $this->environmentService->handle($server),
+                'skip_scripts' => $server->skip_scripts,
             ],
             $server->getUpdatedAtColumn() => $this->formatTimestamp($server->updated_at),
             $server->getCreatedAtColumn() => $this->formatTimestamp($server->created_at),

--- a/app/Transformers/Api/Client/ServerTransformer.php
+++ b/app/Transformers/Api/Client/ServerTransformer.php
@@ -81,6 +81,7 @@ class ServerTransformer extends BaseClientTransformer
             // This field is deprecated, please use "status".
             'is_installing' => ! $server->isInstalled(),
             'is_transferring' => ! is_null($server->transfer),
+            'skip_scripts' => $server->skip_scripts,
             'nest_id' => $server->nest_id,
             'egg_id' => $server->egg_id,
             'egg_image' => $server->egg->image,

--- a/resources/lang/en/admin/server.php
+++ b/resources/lang/en/admin/server.php
@@ -315,6 +315,7 @@ return [
         'bad_variable' => 'There was a validation error with the :name variable.',
         'daemon_exception' => 'There was an exception while attempting to communicate with the daemon resulting in a HTTP/:code response code. This exception has been logged. (request id: :request_id)',
         'default_allocation_not_found' => 'The requested default allocation was not found in this server\'s allocations.',
+        'skipping_install_script' => 'This server is configured to skip its egg\'s install script. Reinstalling is not available until that setting is disabled.',
     ],
 
     'alerts' => [

--- a/resources/lang/en/server/settings.php
+++ b/resources/lang/en/server/settings.php
@@ -29,5 +29,6 @@ return [
         'info-1' => 'Reinstalling your server will stop it, and then re-run the installation script that initially set it up.',
         'info-2' => 'Some files may be deleted or modified during this process, please back up your data before continuing.',
         'button' => 'Reinstall Server',
+        'disabled' => 'Reinstalling is not available because this server is configured to skip its egg\'s install script.',
     ],
 ];

--- a/resources/scripts/api/server/getServer.ts
+++ b/resources/scripts/api/server/getServer.ts
@@ -58,6 +58,7 @@ export interface Server {
         backups: number;
     };
     isTransferring: boolean;
+    skipScripts: boolean;
     variables: ServerEggVariable[];
     allocations: Allocation[];
     category: ServerCategory | null;
@@ -88,6 +89,7 @@ export const rawDataToServerObject = ({ attributes: data }: FractalResponseData)
     eggFeatures: data.egg_features || [],
     featureLimits: { ...data.feature_limits },
     isTransferring: data.is_transferring,
+    skipScripts: data.skip_scripts,
     variables: ((data.relationships?.variables as FractalResponseList | undefined)?.data || []).map(
         rawDataToServerEggVariable
     ),

--- a/resources/scripts/components/server/settings/ReinstallServerBox.tsx
+++ b/resources/scripts/components/server/settings/ReinstallServerBox.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 export default () => {
     const { t } = useTranslation('server/settings');
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
+    const skipScripts = ServerContext.useStoreState((state) => state.server.data!.skipScripts);
     const [modalVisible, setModalVisible] = useState(false);
     const { addFlash, clearFlashes } = useStoreActions((actions: Actions<ApplicationStore>) => actions.flashes);
 
@@ -37,6 +38,16 @@ export default () => {
     useEffect(() => {
         clearFlashes();
     }, []);
+
+    if (skipScripts) {
+        return (
+            <TitledGreyBox title={'Reinstall Server'}>
+                <p css={tw`text-sm`}>
+                    {t('reinstall.disabled')}
+                </p>
+            </TitledGreyBox>
+        );
+    }
 
     return (
         <TitledGreyBox title={t('reinstall.title')} css={tw`relative`}>

--- a/tests/Integration/Api/Application/Servers/ServerControllerTest.php
+++ b/tests/Integration/Api/Application/Servers/ServerControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Integration\Api\Application\Servers;
+
+use Tests\Integration\Api\Application\ApplicationApiIntegrationTestCase;
+
+class ServerControllerTest extends ApplicationApiIntegrationTestCase
+{
+    /**
+     * Test that the "skip scripts" state is returned for a server.
+     */
+    public function test_skip_scripts_state_is_returned()
+    {
+        $server = $this->createServerModel(['skip_scripts' => true]);
+
+        $this->getJson('/api/application/servers/'.$server->id)
+            ->assertOk()
+            ->assertJsonPath('attributes.container.skip_scripts', true);
+
+        $server->update(['skip_scripts' => false]);
+
+        $this->getJson('/api/application/servers/'.$server->id)
+            ->assertOk()
+            ->assertJsonPath('attributes.container.skip_scripts', false);
+    }
+}

--- a/tests/Integration/Api/Application/Servers/ServerManagementControllerTest.php
+++ b/tests/Integration/Api/Application/Servers/ServerManagementControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Integration\Api\Application\Servers;
+
+use App\Models\Server;
+use App\Repositories\Agent\DaemonServerRepository;
+use Illuminate\Http\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Integration\Api\Application\ApplicationApiIntegrationTestCase;
+
+class ServerManagementControllerTest extends ApplicationApiIntegrationTestCase
+{
+    /**
+     * Test that a server can be reinstalled.
+     */
+    public function test_server_can_be_reinstalled()
+    {
+        $server = $this->createServerModel();
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')
+            ->with(\Mockery::on(fn ($value) => $value->uuid === $server->uuid))
+            ->andReturnSelf()
+            ->getMock()
+            ->expects('reinstall')
+            ->andReturnUndefined();
+
+        $this->postJson('/api/application/servers/'.$server->id.'/reinstall')
+            ->assertStatus(Response::HTTP_NO_CONTENT);
+
+        $this->assertSame(Server::STATUS_INSTALLING, $server->refresh()->status);
+    }
+
+    /**
+     * Test that a server configured to skip its egg's install script cannot be reinstalled.
+     */
+    public function test_server_configured_to_skip_scripts_cannot_be_reinstalled()
+    {
+        $server = $this->createServerModel(['skip_scripts' => true]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')->never();
+
+        $this->postJson('/api/application/servers/'.$server->id.'/reinstall')
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJsonPath('errors.0.detail', trans('admin/server.exceptions.skipping_install_script'));
+    }
+
+    /**
+     * Test that a client which does not explicitly ask for JSON still receives the error status
+     * rather than being redirected away from the API.
+     */
+    public function test_blocked_reinstall_returns_an_error_to_clients_not_requesting_json()
+    {
+        $server = $this->createServerModel(['skip_scripts' => true]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')->never();
+
+        $this->post('/api/application/servers/'.$server->id.'/reinstall', [], ['Accept' => '*/*'])
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJsonPath('errors.0.detail', trans('admin/server.exceptions.skipping_install_script'));
+    }
+
+    /**
+     * Test that a server configured to skip its egg's install script can still be reinstalled
+     * while it is in a failed state, since that is the only way to pull it back out of one.
+     */
+    #[DataProvider('recoverableStatusesDataProvider')]
+    public function test_server_configured_to_skip_scripts_can_be_reinstalled_from_a_failed_state(string $status)
+    {
+        $server = $this->createServerModel(['skip_scripts' => true, 'status' => $status]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')
+            ->with(\Mockery::on(fn ($value) => $value->uuid === $server->uuid))
+            ->andReturnSelf()
+            ->getMock()
+            ->expects('reinstall')
+            ->andReturnUndefined();
+
+        $this->postJson('/api/application/servers/'.$server->id.'/reinstall')
+            ->assertStatus(Response::HTTP_NO_CONTENT);
+
+        $this->assertSame(Server::STATUS_INSTALLING, $server->refresh()->status);
+    }
+
+    public static function recoverableStatusesDataProvider(): array
+    {
+        return [
+            [Server::STATUS_INSTALLING],
+            [Server::STATUS_INSTALL_FAILED],
+            [Server::STATUS_REINSTALL_FAILED],
+        ];
+    }
+}

--- a/tests/Integration/Api/Client/Server/SettingsControllerTest.php
+++ b/tests/Integration/Api/Client/Server/SettingsControllerTest.php
@@ -111,6 +111,48 @@ class SettingsControllerTest extends ClientApiIntegrationTestCase
         $this->assertTrue($server->isInstalled());
     }
 
+    /**
+     * Test that a server configured to skip its egg's install script cannot be reinstalled.
+     */
+    #[DataProvider('reinstallPermissionsDataProvider')]
+    public function test_server_cannot_be_reinstalled_if_configured_to_skip_scripts(array $permissions)
+    {
+        [$user, $server] = $this->generateTestAccount($permissions);
+        $server->update(['skip_scripts' => true]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')->never();
+
+        $this->actingAs($user)
+            ->postJson("/api/client/servers/$server->uuid/settings/reinstall")
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJsonPath('errors.0.detail', trans('admin/server.exceptions.skipping_install_script'));
+
+        $this->assertNull($server->refresh()->status);
+    }
+
+    /**
+     * Test that the "skip scripts" state is exposed to the client API.
+     */
+    public function test_skip_scripts_state_is_exposed_to_client()
+    {
+        [$user, $server] = $this->generateTestAccount([Permission::ACTION_SETTINGS_REINSTALL]);
+
+        $this->actingAs($user)
+            ->getJson("/api/client/servers/$server->uuid")
+            ->assertOk()
+            ->assertJsonPath('attributes.skip_scripts', false);
+
+        $server->update(['skip_scripts' => true]);
+
+        $this->actingAs($user)
+            ->getJson("/api/client/servers/$server->uuid")
+            ->assertOk()
+            ->assertJsonPath('attributes.skip_scripts', true);
+    }
+
     public static function renamePermissionsDataProvider(): array
     {
         return [[[]], [[Permission::ACTION_SETTINGS_RENAME]]];


### PR DESCRIPTION
You're able to enable a "skip egg install scripts" per server, while
still being able to reinstall a server. With this setting enabled,
reinstalling a server has no functional use, the server is locked and
shutdown, then simply unlocked immediately afterwards after a success
signal from wings. This PR disables the reinstall button when skip
install scripts is enabled for both the user and admin, with a little
component telling you why you cannot reinstall. The reinstall button is
not disabled if the server is in a status that reinstall could resolve
(eg. failed install).

Fixed by @SkyMulley at https://github.com/pterodactyl/panel/commit/850f2b9a4ff95b5fee64ffa9da74ca53b3f8eaeb