### PR TITLE
Fix unreadable text across panel themes

### DIFF
--- a/app/Filament/Pages/Monitoring.php
+++ b/app/Filament/Pages/Monitoring.php
@@ -135,12 +135,14 @@ class Monitoring extends Page
                         ->content(function () use ($data): HtmlString {
                             $cores = $data['cpu']['per_core'] ?? [];
                             if (empty($cores)) {
-                                return new HtmlString('<span class="text-gray-400">—</span>');
+                                return new HtmlString('<span class="text-gray-600 dark:text-gray-400">—</span>');
                             }
                             $items = array_map(function (int $i, float $pct): string {
-                                $color = $pct >= 80 ? 'text-danger-500' : ($pct >= 50 ? 'text-warning-500' : 'text-success-500');
+                                $color = $pct >= 80
+                                    ? 'monitoring-metric--danger'
+                                    : ($pct >= 50 ? 'monitoring-metric--warning' : 'monitoring-metric--success');
 
-                                return "<div class=\"text-xs\"><span class=\"text-gray-400\">Core {$i}</span> <span class=\"{$color} font-mono\">".number_format($pct, 1).'%</span></div>';
+                                return "<div class=\"text-xs\"><span class=\"text-gray-600 dark:text-gray-400\">Core {$i}</span> <span class=\"{$color} font-mono\">".number_format($pct, 1).'%</span></div>';
                             }, array_keys($cores), $cores);
 
                             return new HtmlString('<div class="grid grid-cols-4 gap-x-4 gap-y-1">'.implode('', $items).'</div>');
@@ -209,7 +211,7 @@ class Monitoring extends Page
                             $partitions = $data['disk']['partitions'] ?? [];
 
                             if (empty($partitions)) {
-                                return new HtmlString('<span class="text-gray-400">'.e(trans('admin/monitoring.details.partitions_none')).'</span>');
+                                return new HtmlString('<span class="text-gray-600 dark:text-gray-400">'.e(trans('admin/monitoring.details.partitions_none')).'</span>');
                             }
 
                             $rows = '';
@@ -225,14 +227,14 @@ class Monitoring extends Page
                                 $pctWidth = min($pct, 100);
 
                                 $rows .= <<<HTML
-                                <tr style="border-bottom:1px solid rgba(255,255,255,0.05)">
-                                    <td style="padding:8px 12px;font-size:12px;color:#f1f5f9;font-family:monospace">{$device}</td>
-                                    <td style="padding:8px 12px;font-size:12px;color:#94a3b8;font-family:monospace">{$mount}</td>
-                                    <td style="padding:8px 12px;font-size:11px;color:#38bdf8;font-family:monospace">{$filesystem}</td>
-                                    <td style="padding:8px 12px;font-size:12px;color:#94a3b8;font-family:monospace">{$used} / {$total}</td>
+                                <tr class="monitoring-table__row">
+                                    <td class="monitoring-table__primary" style="padding:8px 12px;font-size:12px;font-family:monospace">{$device}</td>
+                                    <td class="monitoring-table__muted" style="padding:8px 12px;font-size:12px;font-family:monospace">{$mount}</td>
+                                    <td class="monitoring-table__info" style="padding:8px 12px;font-size:11px;font-family:monospace">{$filesystem}</td>
+                                    <td class="monitoring-table__muted" style="padding:8px 12px;font-size:12px;font-family:monospace">{$used} / {$total}</td>
                                     <td style="padding:8px 12px;min-width:160px">
-                                        <div style="font-size:11px;color:#94a3b8;font-family:monospace;margin-bottom:4px">{$pctLabel}</div>
-                                        <div style="height:5px;width:100%;background:rgba(255,255,255,0.08);border-radius:9999px;overflow:hidden">
+                                        <div class="monitoring-table__muted" style="font-size:11px;font-family:monospace;margin-bottom:4px">{$pctLabel}</div>
+                                        <div class="monitoring-table__track" style="height:5px;width:100%;border-radius:9999px;overflow:hidden">
                                             <div style="height:100%;width:{$pctWidth}%;background:{$pctColor};border-radius:9999px"></div>
                                         </div>
                                     </td>
@@ -245,18 +247,18 @@ class Monitoring extends Page
                             $hFs = e(trans('admin/monitoring.details.partitions_filesystem'));
                             $hSize = e(trans('admin/monitoring.details.partitions_size'));
                             $hUsage = e(trans('admin/monitoring.details.partitions_usage'));
-                            $thStyle = 'padding:8px 12px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:#64748b';
+                            $thStyle = 'padding:8px 12px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em';
 
                             return new HtmlString(<<<HTML
                             <div style="overflow-x:auto;border-radius:8px">
-                                <table style="width:100%;border-collapse:collapse;text-align:left">
+                                <table class="monitoring-table">
                                     <thead>
-                                        <tr style="border-bottom:1px solid rgba(255,255,255,0.08)">
-                                            <th style="{$thStyle}">{$hDevice}</th>
-                                            <th style="{$thStyle}">{$hMount}</th>
-                                            <th style="{$thStyle}">{$hFs}</th>
-                                            <th style="{$thStyle}">{$hSize}</th>
-                                            <th style="{$thStyle}">{$hUsage}</th>
+                                        <tr class="monitoring-table__row">
+                                            <th class="monitoring-table__header" style="{$thStyle}">{$hDevice}</th>
+                                            <th class="monitoring-table__header" style="{$thStyle}">{$hMount}</th>
+                                            <th class="monitoring-table__header" style="{$thStyle}">{$hFs}</th>
+                                            <th class="monitoring-table__header" style="{$thStyle}">{$hSize}</th>
+                                            <th class="monitoring-table__header" style="{$thStyle}">{$hUsage}</th>
                                         </tr>
                                     </thead>
                                     <tbody>{$rows}</tbody>

--- a/app/Filament/Widgets/ServersWidget.php
+++ b/app/Filament/Widgets/ServersWidget.php
@@ -55,17 +55,17 @@ class ServersWidget extends BaseWidget
     private function buildTable(): HtmlString
     {
         if (! $this->selectedNodeId) {
-            return $this->emptyState(trans('admin/monitoring.servers.no_node'), '#94a3b8');
+            return $this->emptyState(trans('admin/monitoring.servers.no_node'));
         }
 
         $agentRows = $this->fetchAgentData();
 
         if ($agentRows === null) {
-            return $this->emptyState(trans('admin/monitoring.servers.error_fetch'), '#f87171');
+            return $this->emptyState(trans('admin/monitoring.servers.error_fetch'), true);
         }
 
         if (empty($agentRows)) {
-            return $this->emptyState(trans('admin/monitoring.servers.no_servers'), '#94a3b8');
+            return $this->emptyState(trans('admin/monitoring.servers.no_servers'));
         }
 
         // Index Agent data by UUID for O(1) lookup.
@@ -97,20 +97,20 @@ class ServersWidget extends BaseWidget
         $hNetwork = e(trans('admin/monitoring.servers.col.network'));
         $hUptime = e(trans('admin/monitoring.servers.col.uptime'));
 
-        $thStyle = 'padding:10px 16px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:#64748b';
+        $thStyle = 'padding:10px 16px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em';
 
         return new HtmlString(<<<HTML
         <div style="overflow-x:auto;border-radius:8px">
-            <table style="width:100%;border-collapse:collapse;text-align:left">
+            <table class="monitoring-table">
                 <thead>
-                    <tr style="border-bottom:1px solid rgba(255,255,255,0.08)">
-                        <th style="{$thStyle}">{$hName}</th>
-                        <th style="{$thStyle}">{$hState}</th>
-                        <th style="{$thStyle};min-width:120px">{$hCpu}</th>
-                        <th style="{$thStyle};min-width:180px">{$hMemory}</th>
-                        <th style="{$thStyle}">{$hDisk}</th>
-                        <th style="{$thStyle}">{$hNetwork}</th>
-                        <th style="{$thStyle}">{$hUptime}</th>
+                    <tr class="monitoring-table__row">
+                        <th class="monitoring-table__header" style="{$thStyle}">{$hName}</th>
+                        <th class="monitoring-table__header" style="{$thStyle}">{$hState}</th>
+                        <th class="monitoring-table__header" style="{$thStyle};min-width:120px">{$hCpu}</th>
+                        <th class="monitoring-table__header" style="{$thStyle};min-width:180px">{$hMemory}</th>
+                        <th class="monitoring-table__header" style="{$thStyle}">{$hDisk}</th>
+                        <th class="monitoring-table__header" style="{$thStyle}">{$hNetwork}</th>
+                        <th class="monitoring-table__header" style="{$thStyle}">{$hUptime}</th>
                     </tr>
                 </thead>
                 <tbody>{$rows}</tbody>
@@ -146,77 +146,71 @@ class ServersWidget extends BaseWidget
         $cpuColor = $cpuPct >= 80 ? '#ef4444' : ($cpuPct >= 60 ? '#eab308' : '#22c55e');
         $memColor = $memPct >= 80 ? '#ef4444' : ($memPct >= 60 ? '#eab308' : '#3b82f6');
 
-        [$badgeHtml, $avatarBorder] = $this->stateBadge($state);
+        $badgeHtml = $this->stateBadge($state);
 
         $initial = e(strtoupper(mb_substr($serverName ?? $uuid, 0, 1)));
         $tdStyle = 'padding:12px 16px;vertical-align:middle';
 
         return <<<HTML
-        <tr style="border-bottom:1px solid rgba(255,255,255,0.05)">
+        <tr class="monitoring-table__row">
             <td style="{$tdStyle}">
                 <div style="display:flex;align-items:center;gap:10px">
-                    <div style="flex-shrink:0;width:32px;height:32px;border-radius:8px;background:rgba(255,255,255,0.06);border:1px solid {$avatarBorder};display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:#f1f5f9">{$initial}</div>
-                    <span style="font-size:13px;font-weight:500;color:#f1f5f9;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:160px" title="{$name}">{$name}</span>
+                    <div class="monitoring-table__avatar" style="flex-shrink:0;width:32px;height:32px;border-radius:8px;border:1px solid var(--gray-300);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700">{$initial}</div>
+                    <span class="monitoring-table__primary" style="font-size:13px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:160px" title="{$name}">{$name}</span>
                 </div>
             </td>
             <td style="{$tdStyle}">{$badgeHtml}</td>
             <td style="{$tdStyle};min-width:120px">
-                <div style="font-size:11px;color:#94a3b8;font-family:monospace;margin-bottom:5px">{$cpuLabel}</div>
-                <div style="height:5px;width:100%;background:rgba(255,255,255,0.08);border-radius:9999px;overflow:hidden">
+                <div class="monitoring-table__muted" style="font-size:11px;font-family:monospace;margin-bottom:5px">{$cpuLabel}</div>
+                <div class="monitoring-table__track" style="height:5px;width:100%;border-radius:9999px;overflow:hidden">
                     <div style="height:100%;width:{$cpuPct}%;background:{$cpuColor};border-radius:9999px"></div>
                 </div>
             </td>
             <td style="{$tdStyle};min-width:180px">
-                <div style="font-size:11px;color:#94a3b8;font-family:monospace;margin-bottom:5px">{$memLabel}</div>
-                <div style="height:5px;width:100%;background:rgba(255,255,255,0.08);border-radius:9999px;overflow:hidden">
+                <div class="monitoring-table__muted" style="font-size:11px;font-family:monospace;margin-bottom:5px">{$memLabel}</div>
+                <div class="monitoring-table__track" style="height:5px;width:100%;border-radius:9999px;overflow:hidden">
                     <div style="height:100%;width:{$memPct}%;background:{$memColor};border-radius:9999px"></div>
                 </div>
             </td>
-            <td style="{$tdStyle};font-size:12px;color:#94a3b8;font-family:monospace">{$diskLabel}</td>
+            <td class="monitoring-table__muted" style="{$tdStyle};font-size:12px;font-family:monospace">{$diskLabel}</td>
             <td style="{$tdStyle}">
                 <div style="font-family:monospace;font-size:11px;line-height:1.7">
-                    <div style="color:#4ade80">↓ {$netRxLabel}</div>
-                    <div style="color:#60a5fa">↑ {$netTxLabel}</div>
+                    <div class="monitoring-table__network--receive">↓ {$netRxLabel}</div>
+                    <div class="monitoring-table__network--transmit">↑ {$netTxLabel}</div>
                 </div>
             </td>
-            <td style="{$tdStyle};font-size:12px;color:#94a3b8;font-family:monospace">{$uptime}</td>
+            <td class="monitoring-table__muted" style="{$tdStyle};font-size:12px;font-family:monospace">{$uptime}</td>
         </tr>
         HTML;
     }
 
-    private function stateBadge(string $state): array
+    private function stateBadge(string $state): string
     {
-        [$bg, $textColor, $dotColor, $border] = match ($state) {
-            'running' => ['rgba(34,197,94,0.12)',  '#4ade80', '#22c55e', 'rgba(34,197,94,0.5)'],
-            'starting' => ['rgba(234,179,8,0.12)',  '#facc15', '#eab308', 'rgba(234,179,8,0.5)'],
-            'stopping' => ['rgba(249,115,22,0.12)', '#fb923c', '#f97316', 'rgba(249,115,22,0.5)'],
-            'offline' => ['rgba(148,163,184,0.08)', '#94a3b8', '#64748b', 'rgba(148,163,184,0.3)'],
-            'crashed' => ['rgba(239,68,68,0.12)',  '#f87171', '#ef4444', 'rgba(239,68,68,0.5)'],
-            default => ['rgba(148,163,184,0.08)', '#94a3b8', '#64748b', 'rgba(148,163,184,0.3)'],
-        };
+        $state = in_array($state, ['running', 'starting', 'stopping', 'offline', 'crashed'], true) ? $state : 'unknown';
 
         $label = e(trans('admin/monitoring.servers.states.'.$state));
 
         $badge = <<<HTML
-        <span style="display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border-radius:9999px;font-size:11px;font-weight:600;background:{$bg};color:{$textColor};border:1px solid {$border}">
-            <span style="width:6px;height:6px;border-radius:50%;background:{$dotColor};flex-shrink:0"></span>
+        <span class="monitoring-state" data-state="{$state}">
+            <span class="monitoring-state__dot"></span>
             {$label}
         </span>
         HTML;
 
-        return [$badge, $border];
+        return $badge;
     }
 
-    private function emptyState(string $message, string $color): HtmlString
+    private function emptyState(string $message, bool $isError = false): HtmlString
     {
         $msg = e($message);
+        $class = $isError ? 'monitoring-empty monitoring-empty--danger' : 'monitoring-empty';
 
         return new HtmlString(<<<HTML
-        <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;padding:48px 0;gap:12px">
-            <svg style="width:40px;height:40px" fill="none" viewBox="0 0 24 24" stroke="#4b5563" stroke-width="1.5">
+        <div class="{$class}" style="display:flex;flex-direction:column;align-items:center;justify-content:center;padding:48px 0;gap:12px">
+            <svg style="width:40px;height:40px" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
             </svg>
-            <p style="font-size:13px;color:{$color}">{$msg}</p>
+            <p style="font-size:13px">{$msg}</p>
         </div>
         HTML);
     }

--- a/app/Http/ViewComposers/DesignifyComposer.php
+++ b/app/Http/ViewComposers/DesignifyComposer.php
@@ -136,6 +136,14 @@ class DesignifyComposer
             'color950' => config('designify.theme7.color950') ?? '#09090b',
         ];
 
+        $this->Theme1['colorMutedText'] = $this->getAccessibleMutedText($this->Theme1);
+        $this->Theme2['colorMutedText'] = $this->getAccessibleMutedText($this->Theme2);
+        $this->Theme3['colorMutedText'] = $this->getAccessibleMutedText($this->Theme3);
+        $this->Theme4['colorMutedText'] = $this->getAccessibleMutedText($this->Theme4);
+        $this->Theme5['colorMutedText'] = $this->getAccessibleMutedText($this->Theme5);
+        $this->Theme6['colorMutedText'] = $this->getAccessibleMutedText($this->Theme6);
+        $this->Theme7['colorMutedText'] = $this->getAccessibleMutedText($this->Theme7);
+
         $this->reviactylDefaults = [
             'customCopyright' => config('designify.customCopyright', true),
             'copyright' => config('designify.copyright') ?? 'Powered by [Reviactyl](https://reviactyl.app/)',
@@ -210,6 +218,68 @@ class DesignifyComposer
             'layoutType' => config('designify.layoutType') ?? 'modern',
             'avatarType' => config('designify.avatarType') ?? 'gravatar',
         ];
+
+        $this->reviactylDefaults['colorMutedText'] = $this->getAccessibleMutedText($this->reviactylDefaults);
+    }
+
+    private function getAccessibleMutedText(array $palette): string
+    {
+        $backgrounds = [$palette['color800'], $palette['color900'], $palette['color950']];
+        $candidates = [
+            $palette['color400'],
+            $palette['color300'],
+            $palette['color200'],
+            $palette['color100'],
+            $palette['color50'],
+            '#ffffff',
+            '#000000',
+        ];
+
+        $bestCandidate = $candidates[0];
+        $bestMinimumContrast = 0.0;
+
+        foreach ($candidates as $candidate) {
+            $minimumContrast = min(array_map(
+                fn (string $background): float => $this->contrastRatio($candidate, $background),
+                $backgrounds,
+            ));
+
+            if ($minimumContrast >= 4.5) {
+                return $candidate;
+            }
+
+            if ($minimumContrast > $bestMinimumContrast) {
+                $bestCandidate = $candidate;
+                $bestMinimumContrast = $minimumContrast;
+            }
+        }
+
+        return $bestCandidate;
+    }
+
+    private function contrastRatio(string $foreground, string $background): float
+    {
+        $foregroundLuminance = $this->relativeLuminance($foreground);
+        $backgroundLuminance = $this->relativeLuminance($background);
+
+        return (max($foregroundLuminance, $backgroundLuminance) + 0.05)
+            / (min($foregroundLuminance, $backgroundLuminance) + 0.05);
+    }
+
+    private function relativeLuminance(string $hex): float
+    {
+        $hex = ltrim($hex, '#');
+        if (strlen($hex) === 3) {
+            $hex = implode('', array_map(fn (string $character): string => $character.$character, str_split($hex)));
+        }
+
+        $channels = array_map(function (string $channel): float {
+            $value = hexdec($channel) / 255;
+
+            return $value <= 0.04045 ? $value / 12.92 : (($value + 0.055) / 1.055) ** 2.4;
+        }, str_split($hex, 2));
+
+        return 0.2126 * $channels[0] + 0.7152 * $channels[1] + 0.0722 * $channels[2];
     }
 
     private function getAlertsConfig(): array

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -38,6 +38,7 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->assets([
                 Css::make('filament-alert', resource_path('css/filament/alert.css')),
+                Css::make('filament-monitoring', resource_path('css/filament/monitoring.css')),
             ])
             ->breadcrumbs(false)
             ->navigationGroups([

--- a/public/css/app/filament-alert.css
+++ b/public/css/app/filament-alert.css
@@ -12,7 +12,8 @@
     padding: 1rem;
     border: 1px solid var(--filament-alert-border);
     border-radius: 0.75rem;
-    background: var(--filament-alert-background);
+    /* Keep the semantic foreground palette coupled to its intended surface. */
+    background-color: var(--filament-alert-background) !important;
     color: var(--filament-alert-text);
     font-size: 0.875rem;
     line-height: 1.5;

--- a/public/css/app/filament-monitoring.css
+++ b/public/css/app/filament-monitoring.css
@@ -1,0 +1,190 @@
+.monitoring-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+}
+
+.monitoring-table__header,
+.monitoring-table__muted {
+    color: var(--gray-600);
+}
+
+.monitoring-table__primary {
+    color: var(--gray-950);
+}
+
+.monitoring-table__row {
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.monitoring-table__avatar {
+    background-color: var(--gray-100);
+    color: var(--gray-950);
+}
+
+.monitoring-table__track {
+    background-color: var(--gray-200);
+}
+
+.monitoring-table__network--receive {
+    color: var(--success-700);
+}
+
+.monitoring-table__network--transmit {
+    color: var(--info-700);
+}
+
+.monitoring-table__info {
+    color: var(--info-700);
+}
+
+.monitoring-empty {
+    color: var(--gray-600);
+}
+
+.monitoring-empty--danger {
+    color: var(--danger-700);
+}
+
+.monitoring-metric--success {
+    color: var(--success-700);
+}
+
+.monitoring-metric--warning {
+    color: var(--warning-700);
+}
+
+.monitoring-metric--danger {
+    color: var(--danger-700);
+}
+
+.monitoring-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.1875rem 0.625rem;
+    border: 1px solid;
+    border-radius: 9999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+}
+
+.monitoring-state__dot {
+    width: 0.375rem;
+    height: 0.375rem;
+    flex-shrink: 0;
+    border-radius: 9999px;
+    background-color: currentColor;
+}
+
+.monitoring-state[data-state='running'] {
+    border-color: var(--success-300);
+    background-color: var(--success-50);
+    color: var(--success-700);
+}
+
+.monitoring-state[data-state='starting'] {
+    border-color: var(--warning-300);
+    background-color: var(--warning-50);
+    color: var(--warning-700);
+}
+
+.monitoring-state[data-state='stopping'] {
+    border-color: var(--warning-300);
+    background-color: var(--warning-50);
+    color: var(--warning-700);
+}
+
+.monitoring-state[data-state='offline'],
+.monitoring-state[data-state='unknown'] {
+    border-color: var(--gray-300);
+    background-color: var(--gray-50);
+    color: var(--gray-700);
+}
+
+.monitoring-state[data-state='crashed'] {
+    border-color: var(--danger-300);
+    background-color: var(--danger-50);
+    color: var(--danger-700);
+}
+
+.dark .monitoring-table__header,
+.dark .monitoring-table__muted {
+    color: var(--gray-400);
+}
+
+.dark .monitoring-table__primary {
+    color: var(--gray-100);
+}
+
+.dark .monitoring-table__row {
+    border-bottom-color: color-mix(in srgb, white 8%, transparent);
+}
+
+.dark .monitoring-table__avatar {
+    background-color: color-mix(in srgb, white 6%, transparent);
+    border-color: var(--gray-700) !important;
+    color: var(--gray-100);
+}
+
+.dark .monitoring-table__track {
+    background-color: color-mix(in srgb, white 8%, transparent);
+}
+
+.dark .monitoring-table__network--receive {
+    color: var(--success-400);
+}
+
+.dark .monitoring-table__network--transmit {
+    color: var(--info-400);
+}
+
+.dark .monitoring-table__info {
+    color: var(--info-400);
+}
+
+.dark .monitoring-empty {
+    color: var(--gray-400);
+}
+
+.dark .monitoring-empty--danger {
+    color: var(--danger-400);
+}
+
+.dark .monitoring-metric--success {
+    color: var(--success-400);
+}
+
+.dark .monitoring-metric--warning {
+    color: var(--warning-400);
+}
+
+.dark .monitoring-metric--danger {
+    color: var(--danger-400);
+}
+
+.dark .monitoring-state[data-state='running'] {
+    border-color: var(--success-700);
+    background-color: color-mix(in srgb, var(--success-400) 12%, transparent);
+    color: var(--success-300);
+}
+
+.dark .monitoring-state[data-state='starting'],
+.dark .monitoring-state[data-state='stopping'] {
+    border-color: var(--warning-700);
+    background-color: color-mix(in srgb, var(--warning-400) 12%, transparent);
+    color: var(--warning-300);
+}
+
+.dark .monitoring-state[data-state='offline'],
+.dark .monitoring-state[data-state='unknown'] {
+    border-color: var(--gray-600);
+    background-color: color-mix(in srgb, var(--gray-400) 8%, transparent);
+    color: var(--gray-300);
+}
+
+.dark .monitoring-state[data-state='crashed'] {
+    border-color: var(--danger-700);
+    background-color: color-mix(in srgb, var(--danger-400) 12%, transparent);
+    color: var(--danger-300);
+}

--- a/resources/css/filament/alert.css
+++ b/resources/css/filament/alert.css
@@ -12,7 +12,8 @@
     padding: 1rem;
     border: 1px solid var(--filament-alert-border);
     border-radius: 0.75rem;
-    background: var(--filament-alert-background);
+    /* Keep the semantic foreground palette coupled to its intended surface. */
+    background-color: var(--filament-alert-background) !important;
     color: var(--filament-alert-text);
     font-size: 0.875rem;
     line-height: 1.5;

--- a/resources/css/filament/monitoring.css
+++ b/resources/css/filament/monitoring.css
@@ -1,0 +1,190 @@
+.monitoring-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+}
+
+.monitoring-table__header,
+.monitoring-table__muted {
+    color: var(--gray-600);
+}
+
+.monitoring-table__primary {
+    color: var(--gray-950);
+}
+
+.monitoring-table__row {
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.monitoring-table__avatar {
+    background-color: var(--gray-100);
+    color: var(--gray-950);
+}
+
+.monitoring-table__track {
+    background-color: var(--gray-200);
+}
+
+.monitoring-table__network--receive {
+    color: var(--success-700);
+}
+
+.monitoring-table__network--transmit {
+    color: var(--info-700);
+}
+
+.monitoring-table__info {
+    color: var(--info-700);
+}
+
+.monitoring-empty {
+    color: var(--gray-600);
+}
+
+.monitoring-empty--danger {
+    color: var(--danger-700);
+}
+
+.monitoring-metric--success {
+    color: var(--success-700);
+}
+
+.monitoring-metric--warning {
+    color: var(--warning-700);
+}
+
+.monitoring-metric--danger {
+    color: var(--danger-700);
+}
+
+.monitoring-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.1875rem 0.625rem;
+    border: 1px solid;
+    border-radius: 9999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+}
+
+.monitoring-state__dot {
+    width: 0.375rem;
+    height: 0.375rem;
+    flex-shrink: 0;
+    border-radius: 9999px;
+    background-color: currentColor;
+}
+
+.monitoring-state[data-state='running'] {
+    border-color: var(--success-300);
+    background-color: var(--success-50);
+    color: var(--success-700);
+}
+
+.monitoring-state[data-state='starting'] {
+    border-color: var(--warning-300);
+    background-color: var(--warning-50);
+    color: var(--warning-700);
+}
+
+.monitoring-state[data-state='stopping'] {
+    border-color: var(--warning-300);
+    background-color: var(--warning-50);
+    color: var(--warning-700);
+}
+
+.monitoring-state[data-state='offline'],
+.monitoring-state[data-state='unknown'] {
+    border-color: var(--gray-300);
+    background-color: var(--gray-50);
+    color: var(--gray-700);
+}
+
+.monitoring-state[data-state='crashed'] {
+    border-color: var(--danger-300);
+    background-color: var(--danger-50);
+    color: var(--danger-700);
+}
+
+.dark .monitoring-table__header,
+.dark .monitoring-table__muted {
+    color: var(--gray-400);
+}
+
+.dark .monitoring-table__primary {
+    color: var(--gray-100);
+}
+
+.dark .monitoring-table__row {
+    border-bottom-color: color-mix(in srgb, white 8%, transparent);
+}
+
+.dark .monitoring-table__avatar {
+    background-color: color-mix(in srgb, white 6%, transparent);
+    border-color: var(--gray-700) !important;
+    color: var(--gray-100);
+}
+
+.dark .monitoring-table__track {
+    background-color: color-mix(in srgb, white 8%, transparent);
+}
+
+.dark .monitoring-table__network--receive {
+    color: var(--success-400);
+}
+
+.dark .monitoring-table__network--transmit {
+    color: var(--info-400);
+}
+
+.dark .monitoring-table__info {
+    color: var(--info-400);
+}
+
+.dark .monitoring-empty {
+    color: var(--gray-400);
+}
+
+.dark .monitoring-empty--danger {
+    color: var(--danger-400);
+}
+
+.dark .monitoring-metric--success {
+    color: var(--success-400);
+}
+
+.dark .monitoring-metric--warning {
+    color: var(--warning-400);
+}
+
+.dark .monitoring-metric--danger {
+    color: var(--danger-400);
+}
+
+.dark .monitoring-state[data-state='running'] {
+    border-color: var(--success-700);
+    background-color: color-mix(in srgb, var(--success-400) 12%, transparent);
+    color: var(--success-300);
+}
+
+.dark .monitoring-state[data-state='starting'],
+.dark .monitoring-state[data-state='stopping'] {
+    border-color: var(--warning-700);
+    background-color: color-mix(in srgb, var(--warning-400) 12%, transparent);
+    color: var(--warning-300);
+}
+
+.dark .monitoring-state[data-state='offline'],
+.dark .monitoring-state[data-state='unknown'] {
+    border-color: var(--gray-600);
+    background-color: color-mix(in srgb, var(--gray-400) 8%, transparent);
+    color: var(--gray-300);
+}
+
+.dark .monitoring-state[data-state='crashed'] {
+    border-color: var(--danger-700);
+    background-color: color-mix(in srgb, var(--danger-400) 12%, transparent);
+    color: var(--danger-300);
+}

--- a/resources/scripts/components/dashboard/forms/SocialLoginsContainer.tsx
+++ b/resources/scripts/components/dashboard/forms/SocialLoginsContainer.tsx
@@ -142,7 +142,7 @@ export default () => {
                                                 })}
                                             </span>
                                         ) : (
-                                            <span css={tw`text-gray-600 flex items-center`}>
+                                            <span css={tw`text-muted flex items-center`}>
                                                 <FaTimesCircle css={tw`mr-1`} />
                                                 {t('overview.social.status.not-connected')}
                                             </span>

--- a/resources/scripts/components/server/backups/BackupRow.tsx
+++ b/resources/scripts/components/server/backups/BackupRow.tsx
@@ -97,7 +97,7 @@ export default ({ backup, className }: Props) => {
                 <p title={format(backup.createdAt, 'ddd, MMMM do, yyyy HH:mm:ss')} css={tw`text-sm`}>
                     {formatDistanceToNow(backup.createdAt, { includeSeconds: true, addSuffix: true })}
                 </p>
-                <p css={tw`text-2xs text-gray-600 uppercase mt-1`}>{t('created')}</p>
+                <p css={tw`text-2xs text-muted uppercase mt-1`}>{t('created')}</p>
             </div>
             <Can action={['backup.download', 'backup.restore', 'backup.delete']} matchAny>
                 <div css={tw`mt-4 md:mt-0 ml-6`} style={{ marginRight: '-0.5rem' }}>

--- a/resources/scripts/components/server/databases/DatabaseRow.tsx
+++ b/resources/scripts/components/server/databases/DatabaseRow.tsx
@@ -156,17 +156,17 @@ export default ({ database, className }: Props) => {
                     <CopyOnClick text={database.connectionString}>
                         <p css={tw`text-sm`}>{database.connectionString}</p>
                     </CopyOnClick>
-                    <p css={tw`mt-1 text-2xs text-gray-600 uppercase select-none`}>{t('endpoint')}</p>
+                    <p css={tw`mt-1 text-2xs text-muted uppercase select-none`}>{t('endpoint')}</p>
                 </div>
                 <div css={tw`ml-8 text-center hidden md:block`}>
                     <p css={tw`text-sm`}>{database.allowConnectionsFrom}</p>
-                    <p css={tw`mt-1 text-2xs text-gray-600 uppercase select-none`}>{t('connections-from')}</p>
+                    <p css={tw`mt-1 text-2xs text-muted uppercase select-none`}>{t('connections-from')}</p>
                 </div>
                 <div css={tw`ml-8 text-center hidden md:block`}>
                     <CopyOnClick text={database.username}>
                         <p css={tw`text-sm`}>{database.username}</p>
                     </CopyOnClick>
-                    <p css={tw`mt-1 text-2xs text-gray-600 uppercase select-none`}>{t('username')}</p>
+                    <p css={tw`mt-1 text-2xs text-muted uppercase select-none`}>{t('username')}</p>
                 </div>
                 <div css={tw`ml-8`}>
                     <Button isSecondary css={tw`mr-2`} onClick={() => setConnectionVisible(true)}>

--- a/resources/scripts/components/server/files/FileManagerBreadcrumbs.tsx
+++ b/resources/scripts/components/server/files/FileManagerBreadcrumbs.tsx
@@ -38,7 +38,7 @@ export default ({ renderLeft, withinFileEditor, isNewFile }: Props) => {
             });
 
     return (
-        <div css={tw`flex flex-grow-0 items-center text-sm text-gray-600 overflow-x-hidden`}>
+        <div css={tw`flex flex-grow-0 items-center text-sm text-muted overflow-x-hidden`}>
             {renderLeft || <div css={tw`w-12`} />}/<span css={tw`px-1 text-gray-300`}>home</span>/
             <NavLink to={`/server/${id}/files`} css={tw`px-1 text-gray-200 no-underline hover:text-gray-100`}>
                 container

--- a/resources/scripts/components/server/files/FileManagerContainer.tsx
+++ b/resources/scripts/components/server/files/FileManagerContainer.tsx
@@ -92,7 +92,7 @@ const RecursiveFileRow = ({ file, serverId }: { file: SearchResult; serverId: st
             <NavLink to={to} className='flex-1 text-sm text-gray-200 truncate hover:text-primary-400 min-w-0'>
                 {file.fullPath}
             </NavLink>
-            {file.isFile && <span className='text-xs text-gray-600 ml-3 flex-none'>{bytesToString(file.size)}</span>}
+            {file.isFile && <span className='text-xs text-muted ml-3 flex-none'>{bytesToString(file.size)}</span>}
         </div>
     );
 };
@@ -385,7 +385,7 @@ export default () => {
                         isSearching && recursiveResults.length === 0 ? (
                             <Spinner size={'base'} centered />
                         ) : recursiveResults.length === 0 ? (
-                            <div className={'flex flex-col items-center justify-center py-10 text-gray-600'}>
+                            <div className={'flex flex-col items-center justify-center py-10 text-muted'}>
                                 <SearchIcon className={'w-10 h-10 mb-2 opacity-40'} />
                                 <p className={'text-sm'}>{t('no-results')}</p>
                             </div>
@@ -395,16 +395,14 @@ export default () => {
                                 animate={{ opacity: 1 }}
                                 transition={{ duration: 0.15, ease: 'easeIn' }}
                             >
-                                {isSearching && (
-                                    <p css={tw`text-xs text-gray-600 text-center mb-2`}>{t('searching')}</p>
-                                )}
+                                {isSearching && <p css={tw`text-xs text-muted text-center mb-2`}>{t('searching')}</p>}
                                 {recursiveResults.map((file) => (
                                     <RecursiveFileRow key={file.fullPath} file={file} serverId={id} />
                                 ))}
                             </motion.div>
                         )
                     ) : !filteredFiles.length ? (
-                        <div className={'flex flex-col items-center justify-center py-10 text-gray-600'}>
+                        <div className={'flex flex-col items-center justify-center py-10 text-muted'}>
                             <FolderOpenIcon className={'w-12 h-12 mb-2 opacity-40'} />
                             <p className={'text-sm'}>{t('empty')}</p>
                         </div>

--- a/resources/scripts/components/server/schedules/ScheduleCronRow.tsx
+++ b/resources/scripts/components/server/schedules/ScheduleCronRow.tsx
@@ -10,23 +10,23 @@ const ScheduleCronRow = ({ cron, className }: Props) => (
     <div className={classNames('flex', className)}>
         <div className={'w-1/5 sm:w-auto text-center'}>
             <p className={'font-medium'}>{cron.minute}</p>
-            <p className={'text-2xs text-gray-600 uppercase'}>Minute</p>
+            <p className={'text-2xs text-muted uppercase'}>Minute</p>
         </div>
         <div className={'w-1/5 sm:w-auto text-center ml-4'}>
             <p className={'font-medium'}>{cron.hour}</p>
-            <p className={'text-2xs text-gray-600 uppercase'}>Hour</p>
+            <p className={'text-2xs text-muted uppercase'}>Hour</p>
         </div>
         <div className={'w-1/5 sm:w-auto text-center ml-4'}>
             <p className={'font-medium'}>{cron.dayOfMonth}</p>
-            <p className={'text-2xs text-gray-600 uppercase'}>Day (Month)</p>
+            <p className={'text-2xs text-muted uppercase'}>Day (Month)</p>
         </div>
         <div className={'w-1/5 sm:w-auto text-center ml-4'}>
             <p className={'font-medium'}>{cron.month}</p>
-            <p className={'text-2xs text-gray-600 uppercase'}>Month</p>
+            <p className={'text-2xs text-muted uppercase'}>Month</p>
         </div>
         <div className={'w-1/5 sm:w-auto text-center ml-4'}>
             <p className={'font-medium'}>{cron.dayOfWeek}</p>
-            <p className={'text-2xs text-gray-600 uppercase'}>Day (Week)</p>
+            <p className={'text-2xs text-muted uppercase'}>Day (Week)</p>
         </div>
     </div>
 );

--- a/resources/scripts/components/server/users/UserRow.tsx
+++ b/resources/scripts/components/server/users/UserRow.tsx
@@ -37,13 +37,13 @@ export default ({ subuser }: Props) => {
                     )}
                     &nbsp;
                 </p>
-                <p css={tw`text-2xs text-gray-600 uppercase hidden md:block`}>{t('two-factor-enabled')}</p>
+                <p css={tw`text-2xs text-muted uppercase hidden md:block`}>{t('two-factor-enabled')}</p>
             </div>
             <div css={tw`ml-4 hidden md:block`}>
                 <p css={tw`font-medium text-center`}>
                     {subuser.permissions.filter((permission) => permission !== 'websocket.connect').length}
                 </p>
-                <p css={tw`text-2xs text-gray-600 uppercase`}>{t('permissions-label')}</p>
+                <p css={tw`text-2xs text-muted uppercase`}>{t('permissions-label')}</p>
             </div>
             {subuser.uuid !== uuid && (
                 <>

--- a/resources/scripts/reviactyl/elements/table/PaginationFooter.tsx
+++ b/resources/scripts/reviactyl/elements/table/PaginationFooter.tsx
@@ -38,12 +38,12 @@ const PaginationFooter = ({ pagination, className, onPageSelect }: Props) => {
 
     return (
         <div className={classNames('flex items-center justify-between my-2', className)}>
-            <p className={'text-sm text-gray-600'}>
+            <p className={'text-sm text-muted'}>
                 Showing&nbsp;
-                <span className={'font-semibold text-gray-400'}>{Math.max(start, Math.min(pagination.total, 1))}</span>
+                <span className={'font-semibold'}>{Math.max(start, Math.min(pagination.total, 1))}</span>
                 &nbsp;to&nbsp;
-                <span className={'font-semibold text-gray-400'}>{end}</span> of&nbsp;
-                <span className={'font-semibold text-gray-400'}>{pagination.total}</span> results.
+                <span className={'font-semibold'}>{end}</span> of&nbsp;
+                <span className={'font-semibold'}>{pagination.total}</span> results.
             </p>
             {pagination.totalPages > 1 && (
                 <div className={'flex space-x-1'}>

--- a/resources/scripts/reviactyl/ui/ContentBlock.tsx
+++ b/resources/scripts/reviactyl/ui/ContentBlock.tsx
@@ -16,7 +16,7 @@ const ContentBlock = ({ title, description, children, ...props }: Props) => {
     return (
         <PageContentBlock title={`${title} | ${name}`} {...props}>
             <Title className='text-4xl mb-2'>{title}</Title>
-            <p className='text-xs text-gray-600'>{description}</p>
+            <p className='text-xs text-muted'>{description}</p>
             {children}
         </PageContentBlock>
     );

--- a/resources/scripts/reviactyl/ui/Footer.tsx
+++ b/resources/scripts/reviactyl/ui/Footer.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
 `;
 
 const Copyright = styled.div`
-    ${tw`text-center text-gray-600 text-xs`}
+    ${tw`text-center text-muted text-xs`}
 `;
 
 export default () => {
@@ -21,7 +21,7 @@ export default () => {
                     rel={'noopener nofollow noreferrer'}
                     href={'https://reviactyl.app'}
                     target={'_blank'}
-                    css={tw`no-underline text-gray-600 hover:text-gray-300`}
+                    css={tw`no-underline text-muted hover:text-gray-300`}
                 >
                     Reviactyl&trade;
                 </a>

--- a/resources/scripts/reviactyl/ui/ThemeEngine.tsx
+++ b/resources/scripts/reviactyl/ui/ThemeEngine.tsx
@@ -20,6 +20,7 @@ type ThemeData = {
     800: string;
     900: string;
     950: string;
+    'muted-text': string;
 };
 
 const getCookie = (name: string): string | null => {
@@ -72,6 +73,7 @@ const getThemeFromConfig = (key: PaletteKey): ThemeData => {
         800: t.color800,
         900: t.color900,
         950: t.color950,
+        'muted-text': t.colorMutedText,
     };
 };
 

--- a/resources/views/filament/widgets/activity-log-summary.blade.php
+++ b/resources/views/filament/widgets/activity-log-summary.blade.php
@@ -10,11 +10,11 @@
                     <div class="flex-1 min-w-0">
                         <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
                             {{ $activity->actor?->name ?? 'System' }} 
-                            <span class="font-normal text-gray-500">
+                            <span class="font-normal text-gray-500 dark:text-gray-400">
                                 {{ $activity->event }}
                             </span>
                         </p>
-                        <p class="text-xs text-gray-500 truncate">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 truncate">
                             @foreach($activity->subjects as $subject)
                                 {{ $subject->subject_type }}: {{ $subject->subject_id }} 
                             @endforeach
@@ -25,7 +25,7 @@
             @endforeach
 
             @if($this->getActivities()->isEmpty())
-                <p class="text-sm text-gray-500 italic">
+                <p class="text-sm text-gray-500 dark:text-gray-400 italic">
                     {{ trans('admin/index.no_activity') }}
                 </p>
             @endif

--- a/resources/views/templates/wrapper.blade.php
+++ b/resources/views/templates/wrapper.blade.php
@@ -122,6 +122,7 @@ SOFTWARE.
             --color-800: {{ reviactyl($panelConfiguration['color800']) }};
             --color-900: {{ reviactyl($panelConfiguration['color900']) }};
             --color-950: {{ reviactyl($panelConfiguration['color950']) }};
+            --color-muted-text: {{ reviactyl($panelConfiguration['colorMutedText']) }};
         }
     </style>
 

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -43,6 +43,7 @@ module.exports = {
                 success: reviactyl('--color-success'),
                 danger: reviactyl('--color-danger'),
                 secondary: reviactyl('--color-secondary'),
+                muted: reviactyl('--color-muted-text'),
             },
             fontSize: {
                 '2xs': '0.625rem',

--- a/tests/Unit/Http/ViewComposers/DesignifyComposerTest.php
+++ b/tests/Unit/Http/ViewComposers/DesignifyComposerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Http\ViewComposers;
+
+use App\Http\ViewComposers\DesignifyComposer;
+use Tests\TestCase;
+
+class DesignifyComposerTest extends TestCase
+{
+    public function test_it_selects_accessible_muted_text_colors_for_each_palette(): void
+    {
+        $view = view('templates.wrapper');
+        app(DesignifyComposer::class)->compose($view);
+
+        $configuration = $view->getData()['panelConfiguration'];
+
+        $this->assertSame('#9f9fa9', $configuration['colorMutedText']);
+        $this->assertSame('#9aa5b1', $configuration['theme1']['colorMutedText']);
+        $this->assertSame('#A2739B', $configuration['theme2']['colorMutedText']);
+        $this->assertSame('#8F7A9E', $configuration['theme3']['colorMutedText']);
+        $this->assertSame('#9E766F', $configuration['theme4']['colorMutedText']);
+        $this->assertSame('#AD9693', $configuration['theme5']['colorMutedText']);
+        $this->assertSame('#94a3b8', $configuration['theme6']['colorMutedText']);
+        $this->assertSame('#a3a3a3', $configuration['theme7']['colorMutedText']);
+
+        $palettes = [
+            'default' => $configuration,
+            'theme1' => $configuration['theme1'],
+            'theme2' => $configuration['theme2'],
+            'theme3' => $configuration['theme3'],
+            'theme4' => $configuration['theme4'],
+            'theme5' => $configuration['theme5'],
+            'theme6' => $configuration['theme6'],
+            'theme7' => $configuration['theme7'],
+        ];
+
+        foreach ($palettes as $name => $palette) {
+            foreach (['color800', 'color900', 'color950'] as $background) {
+                $this->assertGreaterThanOrEqual(
+                    4.5,
+                    $this->contrastRatio($palette['colorMutedText'], $palette[$background]),
+                    "{$name} muted text does not meet WCAG AA against {$background}.",
+                );
+            }
+        }
+    }
+
+    private function contrastRatio(string $foreground, string $background): float
+    {
+        $foregroundLuminance = $this->relativeLuminance($foreground);
+        $backgroundLuminance = $this->relativeLuminance($background);
+
+        return (max($foregroundLuminance, $backgroundLuminance) + 0.05)
+            / (min($foregroundLuminance, $backgroundLuminance) + 0.05);
+    }
+
+    private function relativeLuminance(string $hex): float
+    {
+        $channels = str_split(ltrim($hex, '#'), 2);
+
+        $channels = array_map(function (string $channel): float {
+            $value = hexdec($channel) / 255;
+
+            return $value <= 0.04045 ? $value / 12.92 : (($value + 0.055) / 1.055) ** 2.4;
+        }, $channels);
+
+        return 0.2126 * $channels[0] + 0.7152 * $channels[1] + 0.0722 * $channels[2];
+    }
+}


### PR DESCRIPTION
This PR fixes multiple parts of the panel that were unreadable in certain themes. It introduces a theme-aware muted-text token that meets WCAG AA contrast requirements across every bundled Designify palette. Here are some examples of parts of the panel that used to be unreadable.

<img width="2032" height="108" alt="image" src="https://github.com/user-attachments/assets/24d6b73d-b6f6-4e89-910a-736d3f3d8cd8" />
<img width="2124" height="326" alt="image" src="https://github.com/user-attachments/assets/b8db5dd0-47cc-4a57-819c-cc18153d61a4" />
