### PR TITLE
Fix backup restore state on Agent restart

### DIFF
--- a/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
@@ -102,7 +102,7 @@ class BackupStatusController extends Controller
 
         $model->server->update(['status' => null]);
 
-        Activity::event($request->boolean('successful') ? 'server:backup.restore-complete' : 'server.backup.restore-failed')
+        Activity::event($request->boolean('successful') ? 'server:backup.restore-complete' : 'server:backup.restore-failed')
             ->subject($model, $model->server)
             ->property('name', $model->name)
             ->log();

--- a/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
@@ -100,7 +100,7 @@ class ServerDetailsController extends Controller
         $servers = Server::query()
             ->with([
                 'activity' => fn ($builder) => $builder
-                    ->where('activity_logs.event', 'server:backup.restore-started')
+                    ->where('activity_logs.event', 'server:backup.restore')
                     ->latest('timestamp'),
             ])
             ->where('node_id', $node->id)


### PR DESCRIPTION
This PR fixes an issue where restarting an Agent server during a backup restoration would reset the server state without recording the interrupted restoration as failed. 