### PR TITLE
fix filename spaces deleted through the API

### DIFF
--- a/app/Providers/RouteConfigServiceProvider.php
+++ b/app/Providers/RouteConfigServiceProvider.php
@@ -13,7 +13,7 @@ use Illuminate\Support\ServiceProvider;
 
 class RouteConfigServiceProvider extends ServiceProvider
 {
-    protected const FILE_PATH_REGEX = '/^\/api\/client\/servers\/([a-z0-9-]{36})\/files(\/?$|\/(.)*$)/i';
+    protected const FILE_PATH_REGEX = '/^\/api\/client\/servers\/([^\/]+)\/files(\/?$|\/(.)*$)/i';
 
     /**
      * Define your route model bindings, pattern filters, etc.


### PR DESCRIPTION
This PR fixes an issue where leading and trailing spaces in file paths were removed when file API requests used short or `serv_…` server identifiers. This issue doesn't affect the production panel, but when using an application that relies on a server's 8-character UUID or the `serv_...` format, leading and trailing spaces are removed.