### PR TITLE
Account Activity Log Updates

### DIFF
--- a/app/Http/Controllers/Api/Client/AccountController.php
+++ b/app/Http/Controllers/Api/Client/AccountController.php
@@ -14,6 +14,11 @@ use Illuminate\Http\Response;
 
 class AccountController extends ClientApiController
 {
+    private const FILE_EDITOR_NAMES = [
+        'cm' => 'CodeMirror',
+        'mo' => 'Monaco',
+    ];
+
     /**
      * AccountController constructor.
      */
@@ -106,7 +111,10 @@ class AccountController extends ClientApiController
 
         if ($original !== $user->editor) {
             Activity::event('user:account.file-editor-changed')
-                ->property(['old' => $original, 'new' => $user->editor])
+                ->property([
+                    'old' => self::FILE_EDITOR_NAMES[$original] ?? $original,
+                    'new' => self::FILE_EDITOR_NAMES[$user->editor] ?? $user->editor,
+                ])
                 ->log();
         }
 

--- a/app/Listeners/Auth/PasswordResetListener.php
+++ b/app/Listeners/Auth/PasswordResetListener.php
@@ -17,7 +17,7 @@ class PasswordResetListener
 
     public function handle(PasswordReset $event): void
     {
-        Activity::event('event:password-reset')
+        Activity::event('auth:password-reset')
             ->withRequestMetadata()
             ->subject($event->user)
             ->log();

--- a/resources/lang/en/activity.php
+++ b/resources/lang/en/activity.php
@@ -13,6 +13,9 @@ return [
         'using-api-key' => 'Using API Key',
         'using-sftp' => 'Using SFTP',
     ],
+    'event' => [
+        'password-reset' => 'Password reset',
+    ],
     'auth' => [
         'fail' => 'Failed log in',
         'success' => 'Logged in',
@@ -34,6 +37,7 @@ return [
             'email-changed' => 'Changed email from :old to :new',
             'password-changed' => 'Changed password',
             'language-changed' => 'Changed language from :old to :new',
+            'file-editor-changed' => 'Changed file editor preference',
         ],
         'api-key' => [
             'create' => 'Created new API key :identifier',
@@ -126,6 +130,7 @@ return [
         'settings' => [
             'rename' => 'Renamed the server from :old to :new',
             'description' => 'Changed the server description from :old to :new',
+            'category' => 'Changed server category',
         ],
         'startup' => [
             'edit' => 'Changed the :variable variable from ":old" to ":new"',

--- a/resources/lang/en/activity.php
+++ b/resources/lang/en/activity.php
@@ -37,7 +37,7 @@ return [
             'email-changed' => 'Changed email from :old to :new',
             'password-changed' => 'Changed password',
             'language-changed' => 'Changed language from :old to :new',
-            'file-editor-changed' => 'Changed file editor preference',
+            'file-editor-changed' => 'Changed file editor from :old to :new',
         ],
         'api-key' => [
             'create' => 'Created new API key :identifier',

--- a/resources/scripts/reviactyl/elements/activity/ActivityLogEntry.tsx
+++ b/resources/scripts/reviactyl/elements/activity/ActivityLogEntry.tsx
@@ -64,7 +64,7 @@ export default ({ activity, children }: Props) => {
                             to={`#${pathTo({ event: activity.event })}`}
                             className={'transition-colors duration-75 active:text-cyan-400 hover:text-cyan-400'}
                         >
-                            {activity.event}
+                            <Translate ns={'activity'} values={properties} i18nKey={activity.event.replace(':', '.')} />
                         </Link>
                         <div className={classNames(style.icons, 'group-hover:text-gray-300')}>
                             {activity.isApi && (
@@ -80,9 +80,7 @@ export default ({ activity, children }: Props) => {
                             {children}
                         </div>
                     </div>
-                    <p className={style.description}>
-                        <Translate ns={'activity'} values={properties} i18nKey={activity.event.replace(':', '.')} />
-                    </p>
+                    <p className={style.description}>{activity.event}</p>
                     <div className={'mt-1 flex items-center text-sm'}>
                         {activity.ip && (
                             <span>


### PR DESCRIPTION
This PR adds missing translations to the account-level activity log. It also swaps the placement of the translated text and raw string, since I thought it would be more user-friendly to have the actually readable version bigger. Thanks for reading!