### PR TITLE
Fix Failed Backups Displaying as Successful

### DIFF
--- a/resources/scripts/components/server/backups/BackupRow.tsx
+++ b/resources/scripts/components/server/backups/BackupRow.tsx
@@ -42,7 +42,8 @@ export default ({ backup, className }: Props) => {
                             ? b
                             : {
                                   ...b,
-                                  isSuccessful: parsed.is_successful || true,
+                                  // Older Wings versions omit this field from successful completion events.
+                                  isSuccessful: parsed.is_successful ?? true,
                                   checksum: (parsed.checksum_type || '') + ':' + (parsed.checksum || ''),
                                   bytes: parsed.file_size || 0,
                                   completedAt: new Date(),


### PR DESCRIPTION
This PR fixes an issue where failed backups were displayed as successful. It keeps failure states from newer Wings and Agent versions while keeping compatibility with older Wings versions that don't include the success field. 