### PR TITLE
Fix Transfer Failure Status

### DIFF
--- a/resources/scripts/components/server/TransferListener.tsx
+++ b/resources/scripts/components/server/TransferListener.tsx
@@ -14,7 +14,7 @@ const TransferListener = () => {
             return;
         }
 
-        if (status === 'failed') {
+        if (status === 'failure') {
             setServerFromState((s) => ({ ...s, isTransferring: false }));
             return;
         }


### PR DESCRIPTION
This PR fixes an issue where failed transfers left the Panel interface stuck because it listened for `failed`, while Agent and Wings emit `failure`.