### PR TITLE
Fix File Downloads With Percent Paths

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -82,7 +82,7 @@ class FileController extends ClientApiController
             ->setExpiresAt(CarbonImmutable::now()->addMinutes(15))
             ->setUser($request->user())
             ->setClaims([
-                'file_path' => rawurldecode($request->get('file')),
+                'file_path' => $request->get('file'),
                 'server_uuid' => $server->uuid,
             ])
             ->setScopes(JwtScope::FileDownload)

--- a/tests/Integration/Api/Client/Server/Files/DownloadFileTest.php
+++ b/tests/Integration/Api/Client/Server/Files/DownloadFileTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Integration\Api\Client\Server\Files;
+
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Token\Plain;
+use Tests\Integration\Api\Client\ClientApiIntegrationTestCase;
+
+class DownloadFileTest extends ClientApiIntegrationTestCase
+{
+    public function test_download_token_preserves_percent_sequences_in_file_path(): void
+    {
+        [$user, $server] = $this->generateTestAccount();
+        $path = '/literal%2Fspace%20percent%25dot%2ename.txt';
+
+        $response = $this->actingAs($user)
+            ->getJson($this->link($server, '/files/download').'?'.http_build_query(['file' => $path], encoding_type: PHP_QUERY_RFC3986))
+            ->assertOk();
+
+        $url = $response->json('attributes.url');
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+
+        $config = Configuration::forSymmetricSigner(new Sha256(), InMemory::plainText($server->node->getDecryptedKey()));
+        /** @var Plain $token */
+        $token = $config->parser()->parse($query['token']);
+
+        $this->assertSame($path, $token->claims()->get('file_path'));
+    }
+}


### PR DESCRIPTION
This PR fixes an issue where downloading files named with percent sequences could target a different path because the already-decoded parameter was decoded again. 