### PR TITLE
Fix File Update Permission

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -16,6 +16,7 @@ use App\Http\Requests\Api\Client\Servers\Files\GetFileContentsRequest;
 use App\Http\Requests\Api\Client\Servers\Files\ListFilesRequest;
 use App\Http\Requests\Api\Client\Servers\Files\PullFileRequest;
 use App\Http\Requests\Api\Client\Servers\Files\RenameFileRequest;
+use App\Http\Requests\Api\Client\Servers\Files\UpdateFileContentRequest;
 use App\Http\Requests\Api\Client\Servers\Files\WriteFileContentRequest;
 use App\Models\Server;
 use App\Repositories\Agent\DaemonFileRepository;
@@ -108,6 +109,21 @@ class FileController extends ClientApiController
      * @throws DaemonConnectionException
      */
     public function write(WriteFileContentRequest $request, Server $server): JsonResponse
+    {
+        return $this->writeContent($request, $server);
+    }
+
+    /**
+     * Updates the contents of the specified file on the server.
+     *
+     * @throws DaemonConnectionException
+     */
+    public function update(UpdateFileContentRequest $request, Server $server): JsonResponse
+    {
+        return $this->writeContent($request, $server);
+    }
+
+    private function writeContent(WriteFileContentRequest $request, Server $server): JsonResponse
     {
         $this->fileRepository->setServer($server)->putContent($request->get('file'), $request->getContent());
 

--- a/app/Http/Requests/Api/Client/Servers/Files/UpdateFileContentRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Files/UpdateFileContentRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Requests\Api\Client\Servers\Files;
+
+use App\Models\Permission;
+
+class UpdateFileContentRequest extends WriteFileContentRequest
+{
+    public function permission(): string
+    {
+        return Permission::ACTION_FILE_UPDATE;
+    }
+}

--- a/resources/scripts/api/server/files/updateFileContents.ts
+++ b/resources/scripts/api/server/files/updateFileContents.ts
@@ -1,0 +1,10 @@
+import http from '@/api/http';
+
+export default async (uuid: string, file: string, content: string): Promise<void> => {
+    await http.put(`/api/client/servers/${uuid}/files/write`, content, {
+        params: { file },
+        headers: {
+            'Content-Type': 'text/plain',
+        },
+    });
+};

--- a/resources/scripts/components/server/files/FileEditContainer.tsx
+++ b/resources/scripts/components/server/files/FileEditContainer.tsx
@@ -3,6 +3,7 @@ import getFileContents from '@/api/server/files/getFileContents';
 import { httpErrorToHuman } from '@/api/http';
 import SpinnerOverlay from '@/reviactyl/elements/SpinnerOverlay';
 import saveFileContents from '@/api/server/files/saveFileContents';
+import updateFileContents from '@/api/server/files/updateFileContents';
 import FileManagerBreadcrumbs from '@/components/server/files/FileManagerBreadcrumbs';
 import { useLocation, useNavigate } from 'react-router-dom';
 import FileNameModal from '@/components/server/files/FileNameModal';
@@ -83,7 +84,9 @@ export default () => {
         setLoading(true);
         clearFlashes('files:view');
         fetchFileContent()
-            .then((content) => saveFileContents(uuid, name || hashToPath(hash), content))
+            .then((content) =>
+                name ? saveFileContents(uuid, name, content) : updateFileContents(uuid, hashToPath(hash), content)
+            )
             .then(() => {
                 if (name) {
                     navigate(`/server/${id}/files/edit#/${encodePathSegments(name)}`);

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -102,6 +102,7 @@ Route::group([
         Route::put('/rename', [Client\Servers\FileController::class, 'rename']);
         Route::post('/copy', [Client\Servers\FileController::class, 'copy']);
         Route::post('/write', [Client\Servers\FileController::class, 'write']);
+        Route::put('/write', [Client\Servers\FileController::class, 'update']);
         Route::post('/compress', [Client\Servers\FileController::class, 'compress']);
         Route::post('/decompress', [Client\Servers\FileController::class, 'decompress']);
         Route::post('/delete', [Client\Servers\FileController::class, 'delete']);


### PR DESCRIPTION
This PR fixes an issue where subusers with `file.update` could see the Save Content button but received a 403 when saving an existing file. This is because saving an existing file required the `file.create` permission.