### PR TITLE
Keep Directories First When Sorting Files

### DIFF
--- a/resources/scripts/components/server/files/FileManagerContainer.tsx
+++ b/resources/scripts/components/server/files/FileManagerContainer.tsx
@@ -44,40 +44,7 @@ import {
     FaFileCirclePlus,
 } from 'react-icons/fa6';
 import { Button } from '@/reviactyl/components/button';
-
-type SortType = 'name' | 'size' | 'date';
-type SortDirection = 'asc' | 'desc';
-
-const sortFiles = (
-    files: FileObject[],
-    sortType: SortType = 'name',
-    sortDirection: SortDirection = 'asc'
-): FileObject[] => {
-    const sorted = [...files];
-
-    sorted.sort((a, b) => (a.isFile === b.isFile ? 0 : a.isFile ? 1 : -1));
-
-    const multiplier = sortDirection === 'asc' ? 1 : -1;
-
-    if (sortType === 'name') {
-        sorted.sort((a, b) => a.name.localeCompare(b.name) * multiplier);
-    } else if (sortType === 'size') {
-        sorted.sort((a, b) => {
-            if (a.isFile && b.isFile) {
-                return (a.size - b.size) * multiplier;
-            }
-            return 0;
-        });
-    } else if (sortType === 'date') {
-        sorted.sort((a, b) => {
-            const timeA = a.modifiedAt.getTime();
-            const timeB = b.modifiedAt.getTime();
-            return (timeA - timeB) * multiplier;
-        });
-    }
-
-    return sorted.filter((file, index) => index === 0 || file.name !== sorted[index - 1]?.name);
-};
+import { sortFiles, SortDirection, SortType } from '@/components/server/files/sortFiles';
 
 type SearchResult = FileObject & { fullPath: string };
 

--- a/resources/scripts/components/server/files/sortFiles.ts
+++ b/resources/scripts/components/server/files/sortFiles.ts
@@ -1,0 +1,29 @@
+import { FileObject } from '@/api/server/files/loadDirectory';
+
+export type SortType = 'name' | 'size' | 'date';
+export type SortDirection = 'asc' | 'desc';
+
+export const sortFiles = (
+    files: FileObject[],
+    sortType: SortType = 'name',
+    sortDirection: SortDirection = 'asc'
+): FileObject[] => {
+    const multiplier = sortDirection === 'asc' ? 1 : -1;
+    const sorted = [...files].sort((a, b) => {
+        if (a.isFile !== b.isFile) {
+            return a.isFile ? 1 : -1;
+        }
+
+        if (sortType === 'name') {
+            return a.name.localeCompare(b.name) * multiplier;
+        }
+
+        if (sortType === 'size') {
+            return a.isFile ? (a.size - b.size) * multiplier : 0;
+        }
+
+        return (a.modifiedAt.getTime() - b.modifiedAt.getTime()) * multiplier;
+    });
+
+    return sorted.filter((file, index) => index === 0 || file.name !== sorted[index - 1]?.name);
+};


### PR DESCRIPTION
This PR fixes an issue where sorting files by name or date would mix files and directories together because there was a second sort that ran after mixing files and folders together and disregarding the order the first sort made.