### PR TITLE
Fix Console Resizing After Commands

### DIFF
--- a/resources/scripts/components/server/console/Console.tsx
+++ b/resources/scripts/components/server/console/Console.tsx
@@ -41,7 +41,7 @@ export default () => {
     const TERMINAL_PRELUDE = `\u001b[1m\u001b[33m${containerText} \u001b[0m`;
     const ref = useRef<HTMLDivElement>(null);
     const terminal = useMemo(() => new Terminal({ ...terminalProps }), []);
-    const fitAddon = new FitAddon();
+    const fitAddon = useMemo(() => new FitAddon(), []);
     const searchAddon = new SearchAddon();
     const searchBar = new SearchBarAddon(searchAddon);
     const webLinksAddon = new WebLinksAddon();


### PR DESCRIPTION
This PR fixes an issue where, after running a command, the console stops automatically changing the placement of text based on the size of the browser window. An example is attached below.

<img width="1164" height="90" alt="image" src="https://github.com/user-attachments/assets/0477f493-6f11-46d2-9ca2-7968ada7f54a" />
Here, you can see that after full-screening my console, the error word is cut off and put on a new line, even though there is enough space. It should automatically resize, but since I ran a command before full-screening, it didn't resize.