### PR TITLE
Disable Start While Servers Are Running

### DIFF
--- a/resources/scripts/components/server/console/PowerButtons.tsx
+++ b/resources/scripts/components/server/console/PowerButtons.tsx
@@ -55,7 +55,11 @@ export default ({ className }: PowerButtonProps) => {
             </Dialog.Confirm>
             <Can action={'control.start'}>
                 {(!alwaysShowKillButton || status === 'offline') && (
-                    <Button.Success className={'flex-1'} onClick={onButtonClick.bind(this, 'start')}>
+                    <Button.Success
+                        className={'flex-1'}
+                        disabled={status !== 'offline'}
+                        onClick={onButtonClick.bind(this, 'start')}
+                    >
                         {t('start')}
                     </Button.Success>
                 )}


### PR DESCRIPTION
This PR fixes an issue where the start button of a server would remain active when a server is already started. This issue was originally created after the update to add a kill button.