### PR TITLE
Fix Subuser Permission Issues

### DIFF
--- a/resources/scripts/components/server/backups/BackupContextMenu.tsx
+++ b/resources/scripts/components/server/backups/BackupContextMenu.tsx
@@ -212,12 +212,14 @@ const BackupContextMenu = forwardRef<BackupContextMenuHandle, Props>(({ backup }
                     <ExtensionSlot name={`server:backups:menu:end`} />
                 </DropdownMenu>
             ) : (
-                <button
-                    onClick={() => setModal('delete')}
-                    css={tw`text-gray-200 transition-colors duration-150 hover:text-gray-100 p-2`}
-                >
-                    <FaTrash />
-                </button>
+                <Can action={'backup.delete'}>
+                    <button
+                        onClick={() => setModal('delete')}
+                        css={tw`text-gray-200 transition-colors duration-150 hover:text-gray-100 p-2`}
+                    >
+                        <FaTrash />
+                    </button>
+                </Can>
             )}
         </>
     );

--- a/resources/scripts/components/server/backups/BackupRow.tsx
+++ b/resources/scripts/components/server/backups/BackupRow.tsx
@@ -100,7 +100,10 @@ export default ({ backup, className }: Props) => {
                 </p>
                 <p css={tw`text-2xs text-muted uppercase mt-1`}>{t('created')}</p>
             </div>
-            <Can action={['backup.download', 'backup.restore', 'backup.delete']} matchAny>
+            <Can
+                action={backup.isSuccessful ? ['backup.download', 'backup.restore', 'backup.delete'] : 'backup.delete'}
+                matchAny={backup.isSuccessful}
+            >
                 <div css={tw`mt-4 md:mt-0 ml-6`} style={{ marginRight: '-0.5rem' }}>
                     {!backup.completedAt ? (
                         <div css={tw`p-2 invisible`}>

--- a/resources/scripts/components/server/files/FileDropdownMenu.tsx
+++ b/resources/scripts/components/server/files/FileDropdownMenu.tsx
@@ -194,7 +194,11 @@ const FileDropdownMenu = ({ file }: { file: FileObject }) => {
                         <Row onClick={doArchive} icon={FaFileZipper} title={t('dropdown.archive')} />
                     </Can>
                 )}
-                {file.isFile && <Row onClick={doDownload} icon={FaFileArrowDown} title={t('dropdown.download')} />}
+                {file.isFile && (
+                    <Can action={'file.read-content'}>
+                        <Row onClick={doDownload} icon={FaFileArrowDown} title={t('dropdown.download')} />
+                    </Can>
+                )}
                 <Can action={'file.delete'}>
                     <Row
                         onClick={() => setShowConfirmation(true)}

--- a/resources/scripts/components/server/files/FileManagerContainer.tsx
+++ b/resources/scripts/components/server/files/FileManagerContainer.tsx
@@ -233,14 +233,10 @@ export default () => {
                                         <FaFileCirclePlus className='h-5 w-5' />
                                     </Button.Text>
                                 </Tooltip>
-                                {selectedFilesLength > 0 && (
-                                    <>
-                                        <MassActionsBar />
-                                    </>
-                                )}
                                 <ExtensionSlot name={`server:files:actions:end`} />
                             </div>
                         </Can>
+                        {selectedFilesLength > 0 && <MassActionsBar />}
                         <div className='order-2 md:order-none md:ml-auto flex items-center gap-1 w-full md:w-auto'>
                             <Input
                                 ref={searchInputRef}

--- a/resources/scripts/components/server/files/MassActionsBar.tsx
+++ b/resources/scripts/components/server/files/MassActionsBar.tsx
@@ -13,6 +13,7 @@ import Tooltip from '@/reviactyl/elements/tooltip/Tooltip';
 import { FaFileArrowUp, FaTrash } from 'react-icons/fa6';
 import Spinner from '@/reviactyl/elements/Spinner';
 import { FaFileArchive } from 'react-icons/fa';
+import Can from '@/reviactyl/elements/Can';
 
 const MassActionsBar = () => {
     const { t } = useTranslation('server/files');
@@ -93,25 +94,33 @@ const MassActionsBar = () => {
                     onDismissed={() => setShowMove(false)}
                 />
             )}
-            <span className='border-l border-gray-600 h-5 mx-2' />
-            <Tooltip content={t('move')}>
-                <Button.Text onClick={() => setShowMove(true)} aria-label={t('move')} disabled={loading}>
-                    <FaFileArrowUp className='h-5 w-5' />
-                </Button.Text>
-            </Tooltip>
-            <Tooltip content={t('archive')}>
-                <Button.Success onClick={onClickCompress} aria-label={t('archive')} disabled={loading}>
-                    <FaFileArchive className='h-5 w-5' />
-                </Button.Success>
-            </Tooltip>
-            <Tooltip content={t('delete')}>
-                <Button.Danger onClick={() => setShowConfirm(true)} aria-label={t('delete')} disabled={loading}>
-                    <FaTrash className='h-5 w-5' />
-                </Button.Danger>
-            </Tooltip>
+            <Can action={['file.update', 'file.archive', 'file.delete']} matchAny>
+                <span className='border-l border-gray-600 h-5 mx-2' />
+            </Can>
+            <Can action={'file.update'}>
+                <Tooltip content={t('move')}>
+                    <Button.Text onClick={() => setShowMove(true)} aria-label={t('move')} disabled={loading}>
+                        <FaFileArrowUp className='h-5 w-5' />
+                    </Button.Text>
+                </Tooltip>
+            </Can>
+            <Can action={'file.archive'}>
+                <Tooltip content={t('archive')}>
+                    <Button.Success onClick={onClickCompress} aria-label={t('archive')} disabled={loading}>
+                        <FaFileArchive className='h-5 w-5' />
+                    </Button.Success>
+                </Tooltip>
+            </Can>
+            <Can action={'file.delete'}>
+                <Tooltip content={t('delete')}>
+                    <Button.Danger onClick={() => setShowConfirm(true)} aria-label={t('delete')} disabled={loading}>
+                        <FaTrash className='h-5 w-5' />
+                    </Button.Danger>
+                </Tooltip>
+            </Can>
             {loading && (
                 <Tooltip content={loadingMessage}>
-                    <Button onClick={onClickCompress} aria-label={loadingMessage} className='cursor-wait'>
+                    <Button disabled aria-label={loadingMessage} className='cursor-wait'>
                         <Spinner css={tw`h-5 w-5`} />
                     </Button>
                 </Tooltip>

--- a/resources/scripts/components/server/network/AllocationRow.tsx
+++ b/resources/scripts/components/server/network/AllocationRow.tsx
@@ -19,6 +19,7 @@ import setPrimaryServerAllocation from '@/api/server/network/setPrimaryServerAll
 import getServerAllocations from '@/api/swr/getServerAllocations';
 import { ip } from '@/lib/formatters';
 import Code from '@/reviactyl/elements/Code';
+import { usePermissions } from '@/plugins/usePermissions';
 
 const Label = styled.label`
     ${tw`uppercase text-xs mt-1 text-gray-400 block px-1 select-none transition-colors duration-150`}
@@ -33,6 +34,7 @@ const AllocationRow = ({ allocation }: Props) => {
     const { clearFlashes, clearAndAddHttpError } = useFlashKey('server:network');
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
     const { mutate } = getServerAllocations();
+    const [canUpdate] = usePermissions(['allocation.update']);
 
     const onNotesChanged = useCallback((id: number, notes: string) => {
         mutate((data) => data?.map((a) => (a.id === id ? { ...a, notes } : a)), false);
@@ -86,6 +88,7 @@ const AllocationRow = ({ allocation }: Props) => {
                     <Textarea
                         placeholder={'Notes'}
                         defaultValue={allocation.notes || undefined}
+                        disabled={!canUpdate}
                         onChange={(e) => setAllocationNotes(e.currentTarget.value)}
                     />
                 </InputSpinner>

--- a/resources/scripts/components/server/schedules/NewTaskButton.tsx
+++ b/resources/scripts/components/server/schedules/NewTaskButton.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { Schedule } from '@/api/server/schedules/getServerSchedules';
 import TaskDetailsModal from '@/components/server/schedules/TaskDetailsModal';
 import { Button } from '@/reviactyl/components/button/index';
+import { usePermissions } from '@/plugins/usePermissions';
+import { taskActionPermissions } from '@/components/server/schedules/taskPermissions';
 
 interface Props {
     schedule: Schedule;
@@ -9,6 +11,9 @@ interface Props {
 
 export default ({ schedule }: Props) => {
     const [visible, setVisible] = useState(false);
+    const canCreateTask = usePermissions(taskActionPermissions).some(Boolean);
+
+    if (!canCreateTask) return null;
 
     return (
         <>

--- a/resources/scripts/components/server/schedules/ScheduleTaskRow.tsx
+++ b/resources/scripts/components/server/schedules/ScheduleTaskRow.tsx
@@ -13,6 +13,8 @@ import tw from 'twin.macro';
 import ConfirmationModal from '@/reviactyl/elements/ConfirmationModal';
 import Icon from '@/reviactyl/elements/Icon';
 import { useTranslation } from 'react-i18next';
+import { usePermissions } from '@/plugins/usePermissions';
+import { taskActionPermissions } from '@/components/server/schedules/taskPermissions';
 
 interface Props {
     schedule: Schedule;
@@ -40,6 +42,7 @@ export default ({ schedule, task }: Props) => {
     const [isEditing, setIsEditing] = useState(false);
     const appendSchedule = ServerContext.useStoreActions((actions) => actions.schedules.appendSchedule);
     const { t } = useTranslation('server/schedules');
+    const canEditTask = usePermissions(taskActionPermissions).some(Boolean);
 
     const onConfirmDeletion = () => {
         setIsLoading(true);
@@ -114,16 +117,18 @@ export default ({ schedule, task }: Props) => {
                         </div>
                     </div>
                 )}
-                <Can action={'schedule.update'}>
-                    <button
-                        type={'button'}
-                        aria-label={t('edit-scheduled-task')}
-                        css={tw`block text-sm p-2 text-gray-600 hover:text-gray-100 transition-colors duration-150 mr-4 ml-auto sm:ml-0`}
-                        onClick={() => setIsEditing(true)}
-                    >
-                        <FaPen />
-                    </button>
-                </Can>
+                {canEditTask && (
+                    <Can action={'schedule.update'}>
+                        <button
+                            type={'button'}
+                            aria-label={t('edit-scheduled-task')}
+                            css={tw`block text-sm p-2 text-gray-600 hover:text-gray-100 transition-colors duration-150 mr-4 ml-auto sm:ml-0`}
+                            onClick={() => setIsEditing(true)}
+                        >
+                            <FaPen />
+                        </button>
+                    </Can>
+                )}
                 <Can action={'schedule.update'}>
                     <button
                         type={'button'}

--- a/resources/scripts/components/server/schedules/TaskDetailsModal.tsx
+++ b/resources/scripts/components/server/schedules/TaskDetailsModal.tsx
@@ -17,6 +17,8 @@ import Select from '@/reviactyl/elements/Select';
 import ModalContext from '@/context/ModalContext';
 import asModal from '@/hoc/asModal';
 import FormikSwitch from '@/reviactyl/elements/FormikSwitch';
+import { usePermissions } from '@/plugins/usePermissions';
+import { getTaskActionPermission, taskActionPermissions } from '@/components/server/schedules/taskPermissions';
 
 interface Props {
     schedule: Schedule;
@@ -47,13 +49,13 @@ const schema = object().shape({
         .max(900, 'The time offset must be less than 900 seconds.'),
 });
 
-const ActionListener = () => {
+const ActionListener = ({ defaultPowerAction }: { defaultPowerAction: string }) => {
     const [{ value }, { initialValue: initialAction }] = useField<string>('action');
     const [, { initialValue: initialPayload }, { setValue, setTouched }] = useField<string>('payload');
 
     useEffect(() => {
         if (value !== initialAction) {
-            setValue(value === 'power' ? 'start' : '');
+            setValue(value === 'power' ? defaultPowerAction : '');
             setTouched(false);
         } else {
             setValue(initialPayload || '');
@@ -71,6 +73,25 @@ const TaskDetailsModal = ({ schedule, task }: Props) => {
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
     const appendSchedule = ServerContext.useStoreActions((actions) => actions.schedules.appendSchedule);
     const backupLimit = ServerContext.useStoreState((state) => state.server.data!.featureLimits.backups);
+    const [canSendCommand, canStart, canStop, canRestart, canCreateBackup] = usePermissions(taskActionPermissions);
+    const defaultPowerAction = canStart ? 'start' : canRestart ? 'restart' : canStop ? 'stop' : '';
+    const defaultAction = canSendCommand ? 'command' : defaultPowerAction ? 'power' : 'backup';
+    const taskPermission = task ? getTaskActionPermission(task.action, task.payload) : null;
+    const canEditExistingAction =
+        taskPermission === 'control.console'
+            ? canSendCommand
+            : taskPermission === 'control.start'
+            ? canStart
+            : taskPermission === 'control.stop'
+            ? canStop
+            : taskPermission === 'control.restart'
+            ? canRestart
+            : taskPermission === 'backup.create'
+            ? canCreateBackup
+            : false;
+    const initialAction = task && canEditExistingAction ? task.action : defaultAction;
+    const initialPayload =
+        task && canEditExistingAction ? task.payload : initialAction === 'power' ? defaultPowerAction : '';
 
     useEffect(() => {
         return () => {
@@ -110,8 +131,8 @@ const TaskDetailsModal = ({ schedule, task }: Props) => {
             onSubmit={submit}
             validationSchema={schema}
             initialValues={{
-                action: task?.action || 'command',
-                payload: task?.payload || '',
+                action: initialAction,
+                payload: initialPayload,
                 timeOffset: task?.timeOffset.toString() || '0',
                 continueOnFailure: task?.continueOnFailure || false,
             }}
@@ -123,12 +144,12 @@ const TaskDetailsModal = ({ schedule, task }: Props) => {
                     <div css={tw`flex`}>
                         <div css={tw`mr-2 w-1/3`}>
                             <Label>Action</Label>
-                            <ActionListener />
+                            <ActionListener defaultPowerAction={defaultPowerAction} />
                             <FormikFieldWrapper name={'action'}>
                                 <FormikField as={Select} name={'action'}>
-                                    <option value={'command'}>Send command</option>
-                                    <option value={'power'}>Send power action</option>
-                                    <option value={'backup'}>Create backup</option>
+                                    {canSendCommand && <option value={'command'}>Send command</option>}
+                                    {defaultPowerAction && <option value={'power'}>Send power action</option>}
+                                    {canCreateBackup && <option value={'backup'}>Create backup</option>}
                                 </FormikField>
                             </FormikFieldWrapper>
                         </div>
@@ -155,10 +176,10 @@ const TaskDetailsModal = ({ schedule, task }: Props) => {
                                 <Label>Payload</Label>
                                 <FormikFieldWrapper name={'payload'}>
                                     <FormikField as={Select} name={'payload'}>
-                                        <option value={'start'}>Start the server</option>
-                                        <option value={'restart'}>Restart the server</option>
-                                        <option value={'stop'}>Stop the server</option>
-                                        <option value={'kill'}>Terminate the server</option>
+                                        {canStart && <option value={'start'}>Start the server</option>}
+                                        {canRestart && <option value={'restart'}>Restart the server</option>}
+                                        {canStop && <option value={'stop'}>Stop the server</option>}
+                                        {canStop && <option value={'kill'}>Terminate the server</option>}
                                     </FormikField>
                                 </FormikFieldWrapper>
                             </div>

--- a/resources/scripts/components/server/schedules/taskPermissions.ts
+++ b/resources/scripts/components/server/schedules/taskPermissions.ts
@@ -1,0 +1,22 @@
+export const taskActionPermissions = [
+    'control.console',
+    'control.start',
+    'control.stop',
+    'control.restart',
+    'backup.create',
+];
+
+export const getTaskActionPermission = (action: string, payload: string): string | null => {
+    if (action === 'command') return 'control.console';
+    if (action === 'backup') return 'backup.create';
+
+    if (action === 'power') {
+        const powerAction = payload.trim();
+
+        if (powerAction === 'start') return 'control.start';
+        if (powerAction === 'restart') return 'control.restart';
+        if (powerAction === 'stop' || powerAction === 'kill') return 'control.stop';
+    }
+
+    return null;
+};

--- a/resources/scripts/components/server/startup/StartupContainer.tsx
+++ b/resources/scripts/components/server/startup/StartupContainer.tsx
@@ -16,6 +16,7 @@ import setSelectedDockerImage from '@/api/server/setSelectedDockerImage';
 import InputSpinner from '@/reviactyl/elements/InputSpinner';
 import useFlash from '@/plugins/useFlash';
 import { useTranslation } from 'react-i18next';
+import { usePermissions } from '@/plugins/usePermissions';
 
 const StartupContainer = () => {
     const { t } = useTranslation('server/startup');
@@ -23,6 +24,7 @@ const StartupContainer = () => {
     const { clearFlashes, clearAndAddHttpError } = useFlash();
 
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
+    const [canUpdateDockerImage] = usePermissions(['startup.docker-image']);
     const variables = ServerContext.useStoreState(
         ({ server }) => ({
             variables: server.data!.variables,
@@ -99,9 +101,9 @@ const StartupContainer = () => {
                         <>
                             <InputSpinner visible={loading}>
                                 <Select
-                                    disabled={Object.keys(data.dockerImages).length < 2}
+                                    disabled={!canUpdateDockerImage || Object.keys(data.dockerImages).length < 2}
                                     onChange={updateSelectedDockerImage}
-                                    defaultValue={variables.dockerImage}
+                                    value={variables.dockerImage}
                                 >
                                     {Object.keys(data.dockerImages).map((key) => (
                                         <option key={data.dockerImages[key]} value={data.dockerImages[key]}>


### PR DESCRIPTION
This PR fixes multiple cases where subusers were either shown permissions that the API would block or prevented from performing actions they were allowed to.

1. File mass actions are now available when the subuser has the corresponding `file.update`, `file.archive`, or `file.delete` permission.
2. File downloads are only shown to subusers with `file.read-content`.
3. Failed backup deletion is only shown to subusers with `backup.delete`.
4. Allocation notes are read-only without `allocation.update`.
5. Docker image selection is disabled without `startup.docker-image` and no longer retains an unsaved selection.
6. Schedule task actions are filtered according to `control.console`, `control.start`, `control.stop`, `control.restart`, and 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Improved permission handling across server management screens.
  * Backup download, restore, and deletion actions now reflect backup status and permissions.
  * File downloads, bulk file actions, Docker image updates, and allocation note editing are shown or enabled only when permitted.
  * Schedule task creation, editing, and action selection now respect available permissions.
* **Usability**
  * Unauthorized controls are hidden or disabled to provide a clearer, safer interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->