### PR TITLE
Fix Blank Database Connections Values

### DIFF
--- a/resources/scripts/components/server/databases/CreateDatabaseButton.tsx
+++ b/resources/scripts/components/server/databases/CreateDatabaseButton.tsx
@@ -26,7 +26,10 @@ const schema = object().shape({
             /^[\w\-.]{3,48}$/,
             'Database name should only contain alphanumeric characters, underscores, dashes, and/or periods.'
         ),
-    connectionsFrom: string().matches(/^[\w\-/.%:]+$/, 'A valid host address must be provided.'),
+    connectionsFrom: string().matches(/^[\w\-/.%:]+$/, {
+        message: 'A valid host address must be provided.',
+        excludeEmptyString: true,
+    }),
 });
 
 export default () => {


### PR DESCRIPTION
This PR fixes an issue where leaving the connections from field of a database blank prevented the database from properly creating, even though the UI says it should allow connections from anywhere when blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database connection validation to correctly allow empty values while continuing to enforce valid host-address formats.
  * Preserved the existing validation error message for invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->