### PR TITLE
Fix Dashboard Filters When Viewing Other Servers + Render Accent Below

### DIFF
--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -46,6 +46,8 @@ export default () => {
     const [selectedEggId, setSelectedEggId] = useState<number | null>(null);
     const [eggFilterOpen, setEggFilterOpen] = useState(false);
     const eggFilterRef = useRef<HTMLDivElement>(null);
+    const activeCategory = showAdminServers ? 'all' : selectedCategory;
+    const activeEggId = showAdminServers ? null : selectedEggId;
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
@@ -67,14 +69,14 @@ export default () => {
         error,
         mutate: mutateServers,
     } = useSWR<PaginatedResult<Server>>(
-        ['/api/client/servers', showAdminServers, page, selectedCategory, selectedEggId],
+        ['/api/client/servers', showAdminServers, page, activeCategory, activeEggId],
         () =>
             getServers({
                 page,
                 type: showAdminServers ? 'admin' : undefined,
                 'filter[category_uuid]':
-                    selectedCategory === 'all' ? undefined : selectedCategory === 'primary' ? 'null' : selectedCategory,
-                eggId: selectedEggId ?? undefined,
+                    activeCategory === 'all' ? undefined : activeCategory === 'primary' ? 'null' : activeCategory,
+                eggId: activeEggId ?? undefined,
             })
     );
 
@@ -153,7 +155,7 @@ export default () => {
                 />
             )}
 
-            <div className='flex flex-col gap-4 py-4 md:flex-row md:items-center justify-between'>
+            <div className='relative z-20 flex flex-col gap-4 py-4 md:flex-row md:items-center justify-between'>
                 <div className='min-w-0'>
                     <Title className='text-4xl !font-bold'>
                         {showAdminServers ? t('servers-admin.title') : t('servers-user.title')}
@@ -173,7 +175,10 @@ export default () => {
                                     <Switch
                                         name={'show_all_servers'}
                                         defaultChecked={showOnlyAdmin}
-                                        onChange={() => setShowOnlyAdmin((s) => !s)}
+                                        onChange={() => {
+                                            setShowOnlyAdmin((s) => !s);
+                                            setEggFilterOpen(false);
+                                        }}
                                     />
                                 </div>
                             )}
@@ -290,7 +295,7 @@ export default () => {
                                     <Card css={tw`col-span-1 lg:col-span-2`}>
                                         <p className='flex justify-center text-center text-sm text-gray-400 py-10'>
                                             <EmojiSadIcon className='w-5 h-5 mr-1' />{' '}
-                                            {selectedEggId !== null
+                                            {activeEggId !== null
                                                 ? t('eggs.no-servers-for-egg')
                                                 : showOnlyAdmin
                                                 ? t('no-other-servers')


### PR DESCRIPTION
This PR fixes two issues related to using filters in the dashboard. 

1. As an admin, when you have filters enabled and switch to view other servers mode, the filters you selected apply, including category filters, which make no servers appear if a category filter is enabled. Even though the button isn't visible.
2. The server's status color would render above the selector instead of below, blocking the view of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin dashboard filtering with neutral category and egg filters for more accurate server results and empty-state messages.
  * Closing behavior now works correctly when switching between server scopes.
  * Improved dashboard header layering for more reliable filter interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->