### PR TITLE
Only Decrease Backup Count when Deleting Successful Backups

### DIFF
--- a/resources/scripts/components/server/backups/BackupContextMenu.tsx
+++ b/resources/scripts/components/server/backups/BackupContextMenu.tsx
@@ -65,7 +65,7 @@ const BackupContextMenu = forwardRef<BackupContextMenuHandle, Props>(({ backup }
                     (data) => ({
                         ...data,
                         items: data.items.filter((b) => b.uuid !== backup.uuid),
-                        backupCount: data.backupCount - 1,
+                        backupCount: backup.isSuccessful ? data.backupCount - 1 : data.backupCount,
                     }),
                     false
                 )


### PR DESCRIPTION
This PR fixes an issue where deleting a failed backup would cause the backup count to decrease, even though failed backups don't add to the count when created. This would cause the count to get corrupted and even be able to reach a negative number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected backup count updates when deleting unsuccessful backups.
  * Backup counts now decrease only when a successfully completed backup is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->