### PR TITLE
Fix URL Download Tracking

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Api\Client\Servers\Files\CreateFolderRequest;
 use App\Http\Requests\Api\Client\Servers\Files\DecompressFilesRequest;
 use App\Http\Requests\Api\Client\Servers\Files\DeleteFileRequest;
 use App\Http\Requests\Api\Client\Servers\Files\GetFileContentsRequest;
+use App\Http\Requests\Api\Client\Servers\Files\ListFileDownloadsRequest;
 use App\Http\Requests\Api\Client\Servers\Files\ListFilesRequest;
 use App\Http\Requests\Api\Client\Servers\Files\PullFileRequest;
 use App\Http\Requests\Api\Client\Servers\Files\RenameFileRequest;
@@ -268,7 +269,7 @@ class FileController extends ClientApiController
      */
     public function pull(PullFileRequest $request, Server $server): JsonResponse
     {
-        $this->fileRepository->setServer($server)->pull(
+        $response = $this->fileRepository->setServer($server)->pull(
             $request->input('url'),
             $request->input('directory'),
             $request->safe(['filename', 'use_header', 'foreground'])
@@ -279,6 +280,24 @@ class FileController extends ClientApiController
             ->property('url', $request->input('url'))
             ->log();
 
-        return new JsonResponse([], Response::HTTP_NO_CONTENT);
+        return new JsonResponse(
+            json_decode($response->getBody()->__toString(), true) ?? [],
+            $response->getStatusCode()
+        );
+    }
+
+    /**
+     * Returns all remote file downloads currently being processed by Agent.
+     *
+     * @throws DaemonConnectionException
+     */
+    public function pulls(ListFileDownloadsRequest $request, Server $server): JsonResponse
+    {
+        $response = $this->fileRepository->setServer($server)->getPulls();
+
+        return new JsonResponse(
+            json_decode($response->getBody()->__toString(), true) ?? [],
+            $response->getStatusCode()
+        );
     }
 }

--- a/app/Http/Requests/Api/Client/Servers/Files/ListFileDownloadsRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Files/ListFileDownloadsRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Api\Client\Servers\Files;
+
+use App\Contracts\Http\ClientPermissionsRequest;
+use App\Http\Requests\Api\Client\ClientApiRequest;
+use App\Models\Permission;
+
+class ListFileDownloadsRequest extends ClientApiRequest implements ClientPermissionsRequest
+{
+    public function permission(): string
+    {
+        return Permission::ACTION_FILE_CREATE;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Repositories/Agent/DaemonFileRepository.php
+++ b/app/Repositories/Agent/DaemonFileRepository.php
@@ -298,4 +298,22 @@ class DaemonFileRepository extends DaemonRepository
             throw new DaemonConnectionException($exception);
         }
     }
+
+    /**
+     * Returns all remote file downloads currently being processed for a server.
+     *
+     * @throws DaemonConnectionException
+     */
+    public function getPulls(): ResponseInterface
+    {
+        Assert::isInstanceOf($this->server, Server::class);
+
+        try {
+            return $this->getHttpClient()->get(
+                sprintf('/api/servers/%s/files/pull', $this->server->uuid)
+            );
+        } catch (TransferException $exception) {
+            throw new DaemonConnectionException($exception);
+        }
+    }
 }

--- a/app/Services/Subusers/SubuserPreviewSimulator.php
+++ b/app/Services/Subusers/SubuserPreviewSimulator.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
@@ -83,6 +84,12 @@ class SubuserPreviewSimulator
      */
     private function handleRead(Request $request, \Closure $next, SubuserPreviewContext $context, string $path): mixed
     {
+        if (str_ends_with($path, '/files/pull')) {
+            $this->authorize($context, Permission::ACTION_FILE_CREATE);
+
+            return response()->json(['downloads' => []]);
+        }
+
         if (str_ends_with($path, '/files/upload')) {
             throw new ConflictHttpException(trans('exceptions.subuser_preview.live_connection_unavailable'));
         }
@@ -456,7 +463,7 @@ class SubuserPreviewSimulator
             $filename = (string) ($request->input('filename') ?: basename(parse_url($url, PHP_URL_PATH) ?: 'download'));
             $this->putFile($context, $this->joinPath((string) $request->input('directory', '/'), $filename), true, '');
 
-            return response()->json([], 204);
+            return response()->json(['identifier' => 'preview_'.Str::lower(Str::random(8))], 202);
         }
 
         if ($response = $this->resourceSimulator->write($request, $context, $path)) {

--- a/resources/scripts/api/server/files/getFileDownloads.ts
+++ b/resources/scripts/api/server/files/getFileDownloads.ts
@@ -1,0 +1,11 @@
+import http from '@/api/http';
+
+export interface FileDownload {
+    identifier: string;
+    progress: number;
+}
+
+export default (uuid: string): Promise<FileDownload[]> =>
+    http
+        .get<{ downloads: FileDownload[] }>(`/api/client/servers/${uuid}/files/pull`)
+        .then(({ data }) => data.downloads || []);

--- a/resources/scripts/api/server/files/pullFile.ts
+++ b/resources/scripts/api/server/files/pullFile.ts
@@ -1,9 +1,6 @@
 import http from '@/api/http';
 
-export default (uuid: string, url: string, directory: string): Promise<void> => {
-    return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/files/pull`, { url, directory })
-            .then(() => resolve())
-            .catch(reject);
-    });
-};
+export default (uuid: string, url: string, directory: string): Promise<string> =>
+    http
+        .post<{ identifier: string }>(`/api/client/servers/${uuid}/files/pull`, { url, directory })
+        .then(({ data }) => data.identifier);

--- a/resources/scripts/components/server/files/UrlDownloadButton.tsx
+++ b/resources/scripts/components/server/files/UrlDownloadButton.tsx
@@ -4,6 +4,7 @@ import { Form, Formik, FormikHelpers } from 'formik';
 import Field from '@/reviactyl/elements/Field';
 import { object, string } from 'yup';
 import pullFile from '@/api/server/files/pullFile';
+import getFileDownloads from '@/api/server/files/getFileDownloads';
 import tw from 'twin.macro';
 import { Button } from '@/reviactyl/components/button/index';
 import { useFlashKey } from '@/plugins/useFlash';
@@ -66,6 +67,7 @@ export default ({ className }: WithClassname & { compact?: boolean }) => {
     const [open, setOpen] = useState(false);
     const [downloading, setDownloading] = useState(false);
     const [downloadingFile, setDownloadingFile] = useState<string | null>(null);
+    const [downloadIdentifier, setDownloadIdentifier] = useState<string | null>(null);
 
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
     const directory = ServerContext.useStoreState((state) => state.files.directory);
@@ -73,38 +75,44 @@ export default ({ className }: WithClassname & { compact?: boolean }) => {
     const { clearAndAddHttpError, clearFlashes } = useFlashKey('files:url-download-modal');
 
     useEffect(() => {
-        if (!downloading || !downloadingFile) return;
+        if (!downloading || !downloadIdentifier) return;
 
         let active = true;
-        const poll = setInterval(async () => {
-            const files = await mutate();
-            if (!active) return;
-            if (files?.some((f) => f.name === downloadingFile)) {
+        let poll: ReturnType<typeof setTimeout>;
+        const checkDownload = async () => {
+            try {
+                const downloads = await getFileDownloads(uuid);
+                if (!active) return;
+                if (downloads.some((download) => download.identifier === downloadIdentifier)) {
+                    poll = setTimeout(checkDownload, 2000);
+                    return;
+                }
+
+                await mutate();
+                if (!active) return;
                 setDownloading(false);
                 setDownloadingFile(null);
+                setDownloadIdentifier(null);
+            } catch {
+                if (active) poll = setTimeout(checkDownload, 2000);
             }
-        }, 2000);
-
-        const giveUp = setTimeout(() => {
-            if (!active) return;
-            setDownloading(false);
-            setDownloadingFile(null);
-        }, 60000);
+        };
+        poll = setTimeout(checkDownload, 2000);
 
         return () => {
             active = false;
-            clearInterval(poll);
-            clearTimeout(giveUp);
+            clearTimeout(poll);
         };
-    }, [downloading, downloadingFile]);
+    }, [downloading, downloadIdentifier, uuid]);
 
     const submit = ({ url }: Values, { setSubmitting }: FormikHelpers<Values>) => {
         clearFlashes();
         const filename = extractFilename(url.trim());
         pullFile(uuid, url.trim(), directory)
-            .then(() => {
+            .then((identifier) => {
                 setOpen(false);
                 setDownloadingFile(filename);
+                setDownloadIdentifier(identifier);
                 setDownloading(true);
             })
             .catch((error) => {

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -111,6 +111,7 @@ Route::group([
         Route::post('/delete', [Client\Servers\FileController::class, 'delete']);
         Route::post('/create-folder', [Client\Servers\FileController::class, 'create']);
         Route::post('/chmod', [Client\Servers\FileController::class, 'chmod']);
+        Route::get('/pull', [Client\Servers\FileController::class, 'pulls']);
         Route::middleware([ResourceLimit::FilePull->middleware()])
             ->post('/pull', [Client\Servers\FileController::class, 'pull']);
         Route::get('/upload', Client\Servers\FileUploadController::class);

--- a/tests/Integration/Api/Client/Server/Files/PullFileTest.php
+++ b/tests/Integration/Api/Client/Server/Files/PullFileTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Integration\Api\Client\Server\Files;
+
+use App\Models\Permission;
+use App\Repositories\Agent\DaemonFileRepository;
+use GuzzleHttp\Psr7\Response;
+use Mockery\MockInterface;
+use Tests\Integration\Api\Client\ClientApiIntegrationTestCase;
+
+class PullFileTest extends ClientApiIntegrationTestCase
+{
+    public function test_pull_returns_agent_download_identifier(): void
+    {
+        [$user, $server] = $this->generateTestAccount([Permission::ACTION_FILE_CREATE]);
+
+        $this->mock(DaemonFileRepository::class, function (MockInterface $mock) {
+            $mock->expects('setServer->pull')
+                ->with('https://example.com/archive.tar.gz', '/', [])
+                ->andReturn(new Response(202, [], json_encode(['identifier' => 'download-id'])));
+        });
+
+        $this->actingAs($user)
+            ->postJson($this->link($server, '/files/pull'), [
+                'url' => 'https://example.com/archive.tar.gz',
+                'directory' => '/',
+            ])
+            ->assertAccepted()
+            ->assertExactJson(['identifier' => 'download-id']);
+    }
+
+    public function test_active_downloads_are_returned_from_agent(): void
+    {
+        [$user, $server] = $this->generateTestAccount([Permission::ACTION_FILE_CREATE]);
+
+        $downloads = [
+            ['identifier' => 'download-id', 'progress' => 0.5],
+        ];
+
+        $this->mock(DaemonFileRepository::class, function (MockInterface $mock) use ($downloads) {
+            $mock->expects('setServer->getPulls')
+                ->andReturn(new Response(200, [], json_encode(['downloads' => $downloads])));
+        });
+
+        $this->actingAs($user)
+            ->getJson($this->link($server, '/files/pull'))
+            ->assertOk()
+            ->assertExactJson(['downloads' => $downloads]);
+    }
+
+    public function test_download_status_requires_file_create_permission(): void
+    {
+        [$user, $server] = $this->generateTestAccount([Permission::ACTION_FILE_READ]);
+
+        $this->actingAs($user)
+            ->getJson($this->link($server, '/files/pull'))
+            ->assertForbidden();
+    }
+}

--- a/tests/Integration/Api/Client/Server/Subuser/SubuserPreviewTest.php
+++ b/tests/Integration/Api/Client/Server/Subuser/SubuserPreviewTest.php
@@ -430,6 +430,28 @@ class SubuserPreviewTest extends ClientApiIntegrationTestCase
         $this->assertSame([], SubuserPreviewSession::query()->firstOrFail()->state['files']);
     }
 
+    public function test_preview_url_download_returns_identifier_and_updates_file_state(): void
+    {
+        [$owner, $server, $target] = $this->models();
+        $token = $this->actingAs($owner)->postJson($this->previewEndpoint($server, $target))->json('token');
+
+        $this->withPreviewToken($token)
+            ->postJson($this->link($server, 'files/pull'), [
+                'url' => 'https://example.com/archive.tar.gz',
+                'directory' => '/',
+            ])
+            ->assertAccepted()
+            ->assertJsonStructure(['identifier']);
+
+        $this->withPreviewToken($token)
+            ->getJson($this->link($server, 'files/pull'))
+            ->assertOk()
+            ->assertExactJson(['downloads' => []]);
+
+        $file = SubuserPreviewSession::query()->firstOrFail()->state['files']['/archive.tar.gz'];
+        $this->assertTrue($file['is_file']);
+    }
+
     public function test_preview_websocket_token_is_read_only(): void
     {
         [$owner, $server, $target] = $this->models();


### PR DESCRIPTION
This PR fixes an issue where, if you downloaded a file but another file with the same name already existed, the panel would immediately say the download was finished because tracking was done by the file name rather than the download identifier, which this PR fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for remote file download jobs, including download identifiers and progress.
  * File downloads now update automatically as jobs complete and refresh the file manager.
  * Added an API endpoint to view active file downloads.
  * Preview downloads now return a job identifier for status tracking.

* **Bug Fixes**
  * File pull requests now return the agent’s actual response and status instead of always returning an empty response.
  * Download monitoring now retries after errors and stops cleanly when complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->