### PR TITLE
Fix Horizontal Page Scrolling

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -37,6 +37,7 @@ class AdminPanelProvider extends PanelProvider
                 'primary' => Color::Blue,
             ])
             ->assets([
+                Css::make('filament-layout', resource_path('css/filament/layout.css')),
                 Css::make('filament-alert', resource_path('css/filament/alert.css')),
                 Css::make('filament-monitoring', resource_path('css/filament/monitoring.css')),
             ])

--- a/resources/css/filament/layout.css
+++ b/resources/css/filament/layout.css
@@ -1,0 +1,6 @@
+html,
+body {
+    max-width: 100%;
+    overflow-x: clip;
+    overscroll-behavior-x: none;
+}

--- a/resources/css/filament/layout.css
+++ b/resources/css/filament/layout.css
@@ -2,5 +2,4 @@ html,
 body {
     max-width: 100%;
     overflow-x: clip;
-    overscroll-behavior-x: none;
 }

--- a/resources/scripts/assets/css/GlobalStylesheet.ts
+++ b/resources/scripts/assets/css/GlobalStylesheet.ts
@@ -2,6 +2,14 @@ import tw from 'twin.macro';
 import { createGlobalStyle } from 'styled-components';
 
 export default createGlobalStyle`
+    html,
+    body,
+    #app {
+        max-width: 100%;
+        overflow-x: clip;
+        overscroll-behavior-x: none;
+    }
+
     body {
         ${tw`font-sans bg-gray-950 text-gray-200`};
         letter-spacing: 0.015em;

--- a/resources/scripts/assets/css/GlobalStylesheet.ts
+++ b/resources/scripts/assets/css/GlobalStylesheet.ts
@@ -7,7 +7,6 @@ export default createGlobalStyle`
     #app {
         max-width: 100%;
         overflow-x: clip;
-        overscroll-behavior-x: none;
     }
 
     body {


### PR DESCRIPTION
This PR fixes an issue on MacOS where the panel could be scrolled vertically, which also caused a horizontal scrollbar to appear, making the user experience just generally worse and making the panel feel more clunky. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive behavior by preventing unwanted horizontal scrolling.
  * Ensured the application and admin panel remain constrained to the viewport width.
  * Restored natural horizontal overscroll behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->