### PR TITLE
Fix Compact Layout Breaking Admin View Button

### DIFF
--- a/resources/scripts/reviactyl/components/layouts/SidebarCompact.tsx
+++ b/resources/scripts/reviactyl/components/layouts/SidebarCompact.tsx
@@ -133,11 +133,11 @@ export const NavbarCompact = ({ children }: NavbarProps) => {
                                 </DropdownButtonRow>
                             </NavLink>
                             {rootAdmin && (
-                                <NavLink to='/admin'>
-                                    <DropdownButtonRow>
+                                <a href='/admin' target='_blank' rel='noreferrer'>
+                                    <DropdownButtonRow as='span'>
                                         <FaGears className='h-4 w-4 inline-flex mr-2' /> {t('overview.admin')}
                                     </DropdownButtonRow>
-                                </NavLink>
+                                </a>
                             )}
                             <DropdownButtonRow onClick={onTriggerLogout} danger>
                                 <FaArrowRightToBracket className='h-4 w-4 inline-flex mr-2' /> {t('overview.logout')}


### PR DESCRIPTION
This PR fixes an issue where using the compact layout and attempting to access the admin view would give a 404. This also closes #481.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Root-admin menu items now open the administration area in a new browser tab.
  * Updated the menu interaction to provide a smoother dropdown experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->