### PR TITLE
Add Resend mailer support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ MAIL_PASSWORD=
 MAIL_ENCRYPTION=tls
 MAIL_FROM_ADDRESS=no-reply@example.com
 MAIL_FROM_NAME="Reviactyl Panel"
+RESEND_KEY=
 # You should set this to your domain to prevent it defaulting to 'localhost', causing
 # mail servers such as Gmail to reject your mail.
 #

--- a/app/Filament/Pages/Settings.php
+++ b/app/Filament/Pages/Settings.php
@@ -63,6 +63,7 @@ class Settings extends Page implements HasSchemas
         'mail:mailers:smtp:encryption',
         'mail:mailers:smtp:username',
         'mail:mailers:smtp:password',
+        'mail:mailers:resend:key',
         'mail:from:address',
         'mail:from:name',
 
@@ -123,7 +124,7 @@ class Settings extends Page implements HasSchemas
                 $value = $config->get(Str::replace(':', '.', $key));
             }
 
-            if ($key === 'mail:mailers:smtp:password' && ! empty($value)) {
+            if (in_array($key, ['mail:mailers:smtp:password', 'mail:mailers:resend:key'], true) && ! empty($value)) {
                 try {
                     $value = $encrypter->decrypt($value);
                 } catch (\Throwable) {
@@ -546,7 +547,7 @@ class Settings extends Page implements HasSchemas
                         ->icon('tabler-send')
                         ->action('testMail')
                         ->color('success')
-                        ->visible(fn ($get): bool => $get('mail:default') === 'smtp'),
+                        ->visible(fn ($get): bool => in_array($get('mail:default'), ['smtp', 'resend'], true)),
                 )
                 ->live(),
 
@@ -591,6 +592,18 @@ class Settings extends Page implements HasSchemas
                         ->columnSpan(2),
                 ])
                 ->visible(fn ($get): bool => $get('mail:default') === 'smtp'),
+
+            Group::make()
+                ->columns(4)
+                ->schema([
+                    TextInput::make('mail:mailers:resend:key')
+                        ->label(trans('admin/settings.mail.api-key'))
+                        ->password()
+                        ->revealable()
+                        ->required(fn ($get) => $get('mail:default') === 'resend')
+                        ->columnSpan(4),
+                ])
+                ->visible(fn ($get): bool => $get('mail:default') === 'resend'),
 
             Group::make()
                 ->columns(4)
@@ -682,7 +695,7 @@ class Settings extends Page implements HasSchemas
         $data = $form?->getState() ?? [];
 
         foreach ($data as $key => $value) {
-            if ($key === 'mail:mailers:smtp:password' && ! empty($value)) {
+            if (in_array($key, ['mail:mailers:smtp:password', 'mail:mailers:resend:key'], true) && ! empty($value)) {
                 $value = $encrypter->encrypt($value);
             }
             $settings->set(
@@ -715,6 +728,7 @@ class Settings extends Page implements HasSchemas
         config()->set('mail.mailers.smtp.encryption', $data['mail:mailers:smtp:encryption'] ?? config('mail.mailers.smtp.encryption'));
         config()->set('mail.mailers.smtp.username', $data['mail:mailers:smtp:username'] ?? config('mail.mailers.smtp.username'));
         config()->set('mail.mailers.smtp.password', $data['mail:mailers:smtp:password'] ?? config('mail.mailers.smtp.password'));
+        config()->set('mail.mailers.resend.key', $data['mail:mailers:resend:key'] ?? config('mail.mailers.resend.key'));
 
         config()->set('mail.from.address', $data['mail:from:address'] ?? config('mail.from.address'));
         config()->set('mail.from.name', $data['mail:from:name'] ?? config('mail.from.name'));

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -214,12 +214,19 @@ class SettingsServiceProvider extends ServiceProvider
         'mail:from:name',
     ];
 
+    protected array $resendKeys = [
+        'mail:mailers:resend:key',
+        'mail:from:address',
+        'mail:from:name',
+    ];
+
     /**
      * Keys that are encrypted and should be decrypted when set in the
      * configuration array.
      */
     protected static array $encrypted = [
         'mail:mailers:smtp:password',
+        'mail:mailers:resend:key',
         'panel:auth:google_client_secret',
         'panel:auth:discord_client_secret',
         'panel:auth:github_client_secret',
@@ -257,6 +264,8 @@ class SettingsServiceProvider extends ServiceProvider
         $mailer = array_get($values, 'settings::mail:default', $config->get('mail.default'));
         if ($mailer === 'smtp') {
             $this->keys = array_merge($this->keys, $this->emailKeys);
+        } elseif ($mailer === 'resend') {
+            $this->keys = array_merge($this->keys, $this->resendKeys);
         }
 
         $encrypter = null;

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "predis/predis": "^3.3.0",
         "prologue/alerts": "^1.3.0",
         "psr/cache": "^3.0.0",
+        "resend/resend-php": "^1.0",
         "s1lentium/iptools": "~1.2.0",
         "secondnetwork/blade-tabler-icons": "^3.36",
         "socialiteproviders/discord": "^4.2",

--- a/config/mail.php
+++ b/config/mail.php
@@ -56,6 +56,11 @@ return [
             'transport' => 'postmark',
         ],
 
+        'resend' => [
+            'transport' => 'resend',
+            'key' => env('MAIL_PASSWORD'),
+        ],
+
         'sendmail' => [
             'transport' => 'sendmail',
             'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),

--- a/config/mail.php
+++ b/config/mail.php
@@ -58,7 +58,7 @@ return [
 
         'resend' => [
             'transport' => 'resend',
-            'key' => env('MAIL_PASSWORD'),
+            'key' => env('RESEND_KEY'),
         ],
 
         'sendmail' => [

--- a/resources/lang/en/admin/settings.php
+++ b/resources/lang/en/admin/settings.php
@@ -53,6 +53,7 @@ return [
         'encryption-label' => 'Encryption',
         'username' => 'Username',
         'password' => 'Password',
+        'api-key' => 'API Key',
         'from-label' => 'Mail From',
         'from-name-label' => 'Mail From Name',
         'test-btn' => 'Test',


### PR DESCRIPTION
Adds configuration support for the Resend mail transport across the panel settings flow. This includes a new API key field in the mail settings UI, conditional visibility and required rules when Resend is selected, encryption/decryption and runtime config mapping for the key, provider-side key loading for Resend, and the Resend PHP dependency plus mail/translation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Resend as a supported email delivery provider.
  * Added Resend API key and sender configuration to mail settings.
  * Added the ability to send test emails through Resend.
* **Settings**
  * Resend credentials are securely stored and loaded when selected as the active mail provider.
  * Added a label for the Resend API key field in the administration settings.
  * Added configuration support for the Resend API key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->