### PR TITLE
Don't Rotate Backups on Creation Failure

### DIFF
--- a/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
@@ -12,7 +12,9 @@ use App\Http\Requests\Api\Remote\ReportBackupCompleteRequest;
 use App\Models\Backup;
 use App\Models\Node;
 use App\Models\Server;
+use App\Services\Backups\DeleteBackupService;
 use Carbon\CarbonImmutable;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -22,7 +24,11 @@ class BackupStatusController extends Controller
     /**
      * BackupStatusController constructor.
      */
-    public function __construct(private BackupManager $backupManager) {}
+    public function __construct(
+        private BackupManager $backupManager,
+        private ConnectionInterface $connection,
+        private DeleteBackupService $deleteBackupService,
+    ) {}
 
     /**
      * Handles updating the state of a backup.
@@ -52,12 +58,11 @@ class BackupStatusController extends Controller
             throw new BadRequestHttpException('Cannot update the status of a backup that is already marked as completed.');
         }
 
-        $action = $request->boolean('successful') ? 'server:backup.complete' : 'server:backup.fail';
+        $successful = $request->boolean('successful');
+        $action = $successful ? 'server:backup.complete' : 'server:backup.fail';
         $log = Activity::event($action)->subject($model, $model->server)->property('name', $model->name);
 
-        $log->transaction(function () use ($model, $request) {
-            $successful = $request->boolean('successful');
-
+        $log->transaction(function () use ($model, $request, $successful) {
             $model->fill([
                 'is_successful' => $successful,
                 // Change the lock state to unlocked if this was a failed backup so that it can be
@@ -77,7 +82,46 @@ class BackupStatusController extends Controller
             }
         });
 
+        if ($successful) {
+            $this->rotateBackups($server);
+        }
+
         return new JsonResponse([], JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Removes the oldest unlocked successful backup when a completed replacement exceeds the server limit.
+     */
+    private function rotateBackups(Server $server): void
+    {
+        if ($server->backup_limit <= 0) {
+            return;
+        }
+
+        $this->connection->transaction(function () use ($server) {
+            $backups = $server->backups()
+                ->where(function ($query) {
+                    $query->whereNull('completed_at')
+                        ->orWhere('is_successful', true);
+                })
+                ->lockForUpdate()
+                ->get();
+
+            if ($backups->count() <= $server->backup_limit) {
+                return;
+            }
+
+            $oldest = $backups
+                ->where('is_locked', false)
+                ->where('is_successful', true)
+                ->whereNotNull('completed_at')
+                ->sortBy('created_at')
+                ->first();
+
+            if ($oldest) {
+                $this->deleteBackupService->handle($oldest);
+            }
+        });
     }
 
     /**

--- a/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
@@ -9,12 +9,11 @@ use App\Extensions\Filesystem\S3Filesystem;
 use App\Facades\Activity;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\Remote\ReportBackupCompleteRequest;
+use App\Jobs\Backups\RotateBackupsJob;
 use App\Models\Backup;
 use App\Models\Node;
 use App\Models\Server;
-use App\Services\Backups\DeleteBackupService;
 use Carbon\CarbonImmutable;
-use Illuminate\Database\ConnectionInterface;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -24,11 +23,7 @@ class BackupStatusController extends Controller
     /**
      * BackupStatusController constructor.
      */
-    public function __construct(
-        private BackupManager $backupManager,
-        private ConnectionInterface $connection,
-        private DeleteBackupService $deleteBackupService,
-    ) {}
+    public function __construct(private BackupManager $backupManager) {}
 
     /**
      * Handles updating the state of a backup.
@@ -55,6 +50,12 @@ class BackupStatusController extends Controller
         }
 
         if ($model->is_successful) {
+            if ($request->boolean('successful')) {
+                $this->dispatchBackupRotation($server, $model);
+
+                return new JsonResponse([], JsonResponse::HTTP_NO_CONTENT);
+            }
+
             throw new BadRequestHttpException('Cannot update the status of a backup that is already marked as completed.');
         }
 
@@ -83,45 +84,18 @@ class BackupStatusController extends Controller
         });
 
         if ($successful) {
-            $this->rotateBackups($server);
+            $this->dispatchBackupRotation($server, $model);
         }
 
         return new JsonResponse([], JsonResponse::HTTP_NO_CONTENT);
     }
 
     /**
-     * Removes the oldest unlocked successful backup when a completed replacement exceeds the server limit.
+     * Queues retryable rotation independently from the Agent completion acknowledgement.
      */
-    private function rotateBackups(Server $server): void
+    private function dispatchBackupRotation(Server $server, Backup $backup): void
     {
-        if ($server->backup_limit <= 0) {
-            return;
-        }
-
-        $this->connection->transaction(function () use ($server) {
-            $backups = $server->backups()
-                ->where(function ($query) {
-                    $query->whereNull('completed_at')
-                        ->orWhere('is_successful', true);
-                })
-                ->lockForUpdate()
-                ->get();
-
-            if ($backups->count() <= $server->backup_limit) {
-                return;
-            }
-
-            $oldest = $backups
-                ->where('is_locked', false)
-                ->where('is_successful', true)
-                ->whereNotNull('completed_at')
-                ->sortBy('created_at')
-                ->first();
-
-            if ($oldest) {
-                $this->deleteBackupService->handle($oldest);
-            }
-        });
+        dispatch(new RotateBackupsJob($server->id, $backup->id));
     }
 
     /**

--- a/app/Jobs/Backups/RotateBackupsJob.php
+++ b/app/Jobs/Backups/RotateBackupsJob.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Jobs\Backups;
+
+use App\Jobs\Job;
+use App\Models\Server;
+use App\Services\Backups\RotateBackupsService;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class RotateBackupsJob extends Job implements ShouldBeUnique, ShouldQueue
+{
+    use InteractsWithQueue;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $uniqueFor = 3600;
+
+    public function __construct(public int $serverId, public int $backupId)
+    {
+        $this->queue = 'standard';
+    }
+
+    /**
+     * Removes excess backups after a successful replacement, retrying failures through the queue.
+     */
+    public function handle(RotateBackupsService $service): void
+    {
+        $server = Server::query()->find($this->serverId);
+        if ($server) {
+            $service->handle($server);
+        }
+    }
+
+    /**
+     * Uses increasing delays between the three total attempts.
+     *
+     * @return int[]
+     */
+    public function backoff(): array
+    {
+        return [30, 120];
+    }
+
+    /**
+     * Prevents duplicate cleanup jobs for the same completed backup.
+     */
+    public function uniqueId(): string
+    {
+        return (string) $this->backupId;
+    }
+}

--- a/app/Services/Backups/InitiateBackupService.php
+++ b/app/Services/Backups/InitiateBackupService.php
@@ -88,6 +88,7 @@ class InitiateBackupService
         // Check if the server has reached or exceeded its backup limit.
         // completed_at == null will cover any ongoing backups, while is_successful == true will cover any completed backups.
         $successful = $this->repository->getNonFailedBackups($server);
+        $oldest = null;
         if (! $server->backup_limit || $successful->count() >= $server->backup_limit) {
             // Do not allow the user to continue if this server is already at its limit and can't override.
             if (! $override || $server->backup_limit <= 0) {
@@ -95,17 +96,16 @@ class InitiateBackupService
             }
 
             // Get the oldest backup the server has that is not "locked" (indicating a backup that should
-            // never be automatically purged). If we find a backup we will delete it and then continue with
-            // this process. If no backup is found that can be used an exception is thrown.
+            // never be automatically purged). If no backup is found that can be used an exception is thrown.
+            // The backup is deleted only after Agent accepts the replacement request so a failed request
+            // does not leave the server without its existing backup.
             $oldest = $successful->where('is_locked', false)->orderBy('created_at')->first();
             if (! $oldest) {
                 throw new TooManyBackupsException($server->backup_limit);
             }
-
-            $this->deleteBackupService->handle($oldest);
         }
 
-        return $this->connection->transaction(function () use ($server, $name) {
+        $backup = $this->connection->transaction(function () use ($server, $name) {
             /** @var Backup $backup */
             $backup = $this->repository->create([
                 'server_id' => $server->id,
@@ -122,5 +122,11 @@ class InitiateBackupService
 
             return $backup;
         });
+
+        if ($oldest) {
+            $this->deleteBackupService->handle($oldest);
+        }
+
+        return $backup;
     }
 }

--- a/app/Services/Backups/InitiateBackupService.php
+++ b/app/Services/Backups/InitiateBackupService.php
@@ -27,7 +27,6 @@ class InitiateBackupService
         private BackupRepository $repository,
         private ConnectionInterface $connection,
         private DaemonBackupRepository $daemonBackupRepository,
-        private DeleteBackupService $deleteBackupService,
         private BackupManager $backupManager,
     ) {}
 
@@ -88,24 +87,20 @@ class InitiateBackupService
         // Check if the server has reached or exceeded its backup limit.
         // completed_at == null will cover any ongoing backups, while is_successful == true will cover any completed backups.
         $successful = $this->repository->getNonFailedBackups($server);
-        $oldest = null;
         if (! $server->backup_limit || $successful->count() >= $server->backup_limit) {
             // Do not allow the user to continue if this server is already at its limit and can't override.
             if (! $override || $server->backup_limit <= 0) {
                 throw new TooManyBackupsException($server->backup_limit);
             }
 
-            // Get the oldest backup the server has that is not "locked" (indicating a backup that should
-            // never be automatically purged). If no backup is found that can be used an exception is thrown.
-            // The backup is deleted only after Agent accepts the replacement request so a failed request
-            // does not leave the server without its existing backup.
-            $oldest = $successful->where('is_locked', false)->orderBy('created_at')->first();
-            if (! $oldest) {
+            // Ensure a backup is available for rotation. It is selected and deleted only after the
+            // replacement reports a successful completion so failed backups preserve the existing copy.
+            if (! $successful->where('is_locked', false)->exists()) {
                 throw new TooManyBackupsException($server->backup_limit);
             }
         }
 
-        $backup = $this->connection->transaction(function () use ($server, $name) {
+        return $this->connection->transaction(function () use ($server, $name) {
             /** @var Backup $backup */
             $backup = $this->repository->create([
                 'server_id' => $server->id,
@@ -122,11 +117,5 @@ class InitiateBackupService
 
             return $backup;
         });
-
-        if ($oldest) {
-            $this->deleteBackupService->handle($oldest);
-        }
-
-        return $backup;
     }
 }

--- a/app/Services/Backups/RotateBackupsService.php
+++ b/app/Services/Backups/RotateBackupsService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services\Backups;
+
+use App\Models\Server;
+use Illuminate\Database\ConnectionInterface;
+
+class RotateBackupsService
+{
+    public function __construct(
+        private ConnectionInterface $connection,
+        private DeleteBackupService $deleteBackupService,
+    ) {}
+
+    /**
+     * Removes the oldest unlocked successful backup when completed backups exceed the server limit.
+     */
+    public function handle(Server $server): void
+    {
+        if ($server->backup_limit <= 0) {
+            return;
+        }
+
+        $this->connection->transaction(function () use ($server) {
+            $backups = $server->backups()
+                ->where(function ($query) {
+                    $query->whereNull('completed_at')
+                        ->orWhere('is_successful', true);
+                })
+                ->lockForUpdate()
+                ->get();
+
+            if ($backups->count() <= $server->backup_limit) {
+                return;
+            }
+
+            $oldest = $backups
+                ->where('is_locked', false)
+                ->where('is_successful', true)
+                ->whereNotNull('completed_at')
+                ->sortBy('created_at')
+                ->first();
+
+            if ($oldest) {
+                $this->deleteBackupService->handle($oldest);
+            }
+        });
+    }
+}

--- a/tests/Integration/Api/Remote/BackupStatusControllerTest.php
+++ b/tests/Integration/Api/Remote/BackupStatusControllerTest.php
@@ -2,15 +2,22 @@
 
 namespace Tests\Integration\Api\Remote;
 
+use App\Jobs\Backups\RotateBackupsJob;
 use App\Models\Backup;
 use App\Models\Server;
-use App\Repositories\Agent\DaemonBackupRepository;
 use Carbon\CarbonImmutable;
-use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Queue;
 use Tests\Integration\IntegrationTestCase;
 
 class BackupStatusControllerTest extends IntegrationTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
     public function test_failed_replacement_preserves_existing_backup(): void
     {
         $server = $this->createServerModel(['backup_limit' => 1]);
@@ -25,9 +32,10 @@ class BackupStatusControllerTest extends IntegrationTestCase
         $this->assertNotSoftDeleted($existing);
         $this->assertFalse($replacement->refresh()->is_successful);
         $this->assertNotNull($replacement->completed_at);
+        Queue::assertNotPushed(RotateBackupsJob::class);
     }
 
-    public function test_successful_replacement_deletes_oldest_backup(): void
+    public function test_successful_replacement_queues_backup_rotation(): void
     {
         $server = $this->createServerModel(['backup_limit' => 1]);
         $existing = Backup::factory()->for($server)->create(['created_at' => CarbonImmutable::now()->subHour()]);
@@ -36,41 +44,27 @@ class BackupStatusControllerTest extends IntegrationTestCase
             'completed_at' => null,
         ]);
 
-        $this->expectBackupDeletion($existing);
-
-        $this->sendBackupStatus($server, $replacement, true)->assertNoContent();
-
-        $this->assertSoftDeleted($existing);
-        $this->assertTrue($replacement->refresh()->is_successful);
-    }
-
-    public function test_backup_locked_before_replacement_completes_is_preserved(): void
-    {
-        $server = $this->createServerModel(['backup_limit' => 1]);
-        $existing = Backup::factory()->for($server)->create([
-            'created_at' => CarbonImmutable::now()->subHour(),
-            'is_locked' => true,
-        ]);
-        $replacement = Backup::factory()->for($server)->create([
-            'is_successful' => false,
-            'completed_at' => null,
-        ]);
-
-        $this->expectBackupDeletion($replacement);
-
         $this->sendBackupStatus($server, $replacement, true)->assertNoContent();
 
         $this->assertNotSoftDeleted($existing);
-        $this->assertSoftDeleted($replacement);
+        $this->assertTrue($replacement->refresh()->is_successful);
+        Queue::assertPushed(RotateBackupsJob::class, function (RotateBackupsJob $job) use ($server, $replacement) {
+            return $job->serverId === $server->id
+                && $job->backupId === $replacement->id
+                && $job->tries === 3;
+        });
     }
 
-    private function expectBackupDeletion(Backup $expected): void
+    public function test_successful_status_retry_queues_rotation_again(): void
     {
-        $repository = $this->mock(DaemonBackupRepository::class);
-        $repository->expects('setServer')->andReturnSelf();
-        $repository->expects('delete')->with(\Mockery::on(function ($backup) use ($expected) {
-            return $backup instanceof Backup && $backup->id === $expected->id;
-        }))->andReturn(new Response());
+        $server = $this->createServerModel(['backup_limit' => 1]);
+        $replacement = Backup::factory()->for($server)->create();
+
+        $this->sendBackupStatus($server, $replacement, true)->assertNoContent();
+
+        Queue::assertPushed(RotateBackupsJob::class, function (RotateBackupsJob $job) use ($replacement) {
+            return $job->backupId === $replacement->id;
+        });
     }
 
     private function sendBackupStatus(Server $server, Backup $backup, bool $successful)

--- a/tests/Integration/Api/Remote/BackupStatusControllerTest.php
+++ b/tests/Integration/Api/Remote/BackupStatusControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Integration\Api\Remote;
+
+use App\Models\Backup;
+use App\Models\Server;
+use App\Repositories\Agent\DaemonBackupRepository;
+use Carbon\CarbonImmutable;
+use GuzzleHttp\Psr7\Response;
+use Tests\Integration\IntegrationTestCase;
+
+class BackupStatusControllerTest extends IntegrationTestCase
+{
+    public function test_failed_replacement_preserves_existing_backup(): void
+    {
+        $server = $this->createServerModel(['backup_limit' => 1]);
+        $existing = Backup::factory()->for($server)->create(['created_at' => CarbonImmutable::now()->subHour()]);
+        $replacement = Backup::factory()->for($server)->create([
+            'is_successful' => false,
+            'completed_at' => null,
+        ]);
+
+        $this->sendBackupStatus($server, $replacement, false)->assertNoContent();
+
+        $this->assertNotSoftDeleted($existing);
+        $this->assertFalse($replacement->refresh()->is_successful);
+        $this->assertNotNull($replacement->completed_at);
+    }
+
+    public function test_successful_replacement_deletes_oldest_backup(): void
+    {
+        $server = $this->createServerModel(['backup_limit' => 1]);
+        $existing = Backup::factory()->for($server)->create(['created_at' => CarbonImmutable::now()->subHour()]);
+        $replacement = Backup::factory()->for($server)->create([
+            'is_successful' => false,
+            'completed_at' => null,
+        ]);
+
+        $this->expectBackupDeletion($existing);
+
+        $this->sendBackupStatus($server, $replacement, true)->assertNoContent();
+
+        $this->assertSoftDeleted($existing);
+        $this->assertTrue($replacement->refresh()->is_successful);
+    }
+
+    public function test_backup_locked_before_replacement_completes_is_preserved(): void
+    {
+        $server = $this->createServerModel(['backup_limit' => 1]);
+        $existing = Backup::factory()->for($server)->create([
+            'created_at' => CarbonImmutable::now()->subHour(),
+            'is_locked' => true,
+        ]);
+        $replacement = Backup::factory()->for($server)->create([
+            'is_successful' => false,
+            'completed_at' => null,
+        ]);
+
+        $this->expectBackupDeletion($replacement);
+
+        $this->sendBackupStatus($server, $replacement, true)->assertNoContent();
+
+        $this->assertNotSoftDeleted($existing);
+        $this->assertSoftDeleted($replacement);
+    }
+
+    private function expectBackupDeletion(Backup $expected): void
+    {
+        $repository = $this->mock(DaemonBackupRepository::class);
+        $repository->expects('setServer')->andReturnSelf();
+        $repository->expects('delete')->with(\Mockery::on(function ($backup) use ($expected) {
+            return $backup instanceof Backup && $backup->id === $expected->id;
+        }))->andReturn(new Response());
+    }
+
+    private function sendBackupStatus(Server $server, Backup $backup, bool $successful)
+    {
+        $data = ['successful' => $successful];
+        if ($successful) {
+            $data += [
+                'checksum' => 'test',
+                'checksum_type' => 'sha256',
+                'size' => 123,
+            ];
+        }
+
+        return $this
+            ->withHeader('Authorization', "Bearer {$server->node->daemon_token_id}.{$server->node->getDecryptedKey()}")
+            ->postJson("/api/remote/backups/{$backup->uuid}", $data);
+    }
+}

--- a/tests/Integration/Jobs/Backups/RotateBackupsJobTest.php
+++ b/tests/Integration/Jobs/Backups/RotateBackupsJobTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Integration\Jobs\Backups;
+
+use App\Exceptions\Http\Connection\DaemonConnectionException;
+use App\Jobs\Backups\RotateBackupsJob;
+use App\Models\Backup;
+use App\Repositories\Agent\DaemonBackupRepository;
+use App\Services\Backups\RotateBackupsService;
+use Carbon\CarbonImmutable;
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Tests\Integration\IntegrationTestCase;
+
+class RotateBackupsJobTest extends IntegrationTestCase
+{
+    public function test_deletion_failure_can_be_retried_and_then_completes_rotation(): void
+    {
+        $server = $this->createServerModel(['backup_limit' => 1]);
+        $existing = Backup::factory()->for($server)->create(['created_at' => CarbonImmutable::now()->subHour()]);
+        $replacement = Backup::factory()->for($server)->create();
+        $attempts = 0;
+
+        $repository = $this->mock(DaemonBackupRepository::class);
+        $repository->allows('setServer')->andReturnSelf();
+        $repository->expects('delete')->twice()->andReturnUsing(function () use (&$attempts) {
+            if (++$attempts === 1) {
+                throw new DaemonConnectionException(
+                    new BadResponseException('Deletion failed', new Request('DELETE', '/backup'), new Response(500))
+                );
+            }
+
+            return new Response();
+        });
+
+        $job = new RotateBackupsJob($server->id, $replacement->id);
+
+        try {
+            $job->handle($this->app->make(RotateBackupsService::class));
+        } catch (DaemonConnectionException) {
+            // The queue will retry this failed attempt.
+        }
+
+        $this->assertSame(3, $job->tries);
+        $this->assertNotSoftDeleted($existing);
+
+        $job->handle($this->app->make(RotateBackupsService::class));
+
+        $this->assertSame(2, $attempts);
+        $this->assertSoftDeleted($existing);
+        $this->assertNotSoftDeleted($replacement);
+    }
+
+    public function test_backup_locked_before_cleanup_is_preserved(): void
+    {
+        $server = $this->createServerModel(['backup_limit' => 1]);
+        $existing = Backup::factory()->for($server)->create([
+            'created_at' => CarbonImmutable::now()->subHour(),
+            'is_locked' => true,
+        ]);
+        $replacement = Backup::factory()->for($server)->create();
+
+        $repository = $this->mock(DaemonBackupRepository::class);
+        $repository->allows('setServer')->andReturnSelf();
+        $repository->expects('delete')->with(\Mockery::on(function ($backup) use ($replacement) {
+            return $backup instanceof Backup && $backup->id === $replacement->id;
+        }))->andReturn(new Response());
+
+        (new RotateBackupsJob($server->id, $replacement->id))
+            ->handle($this->app->make(RotateBackupsService::class));
+
+        $this->assertNotSoftDeleted($existing);
+        $this->assertSoftDeleted($replacement);
+    }
+
+    public function test_cleanup_is_limited_to_three_failed_attempts(): void
+    {
+        $server = $this->createServerModel(['backup_limit' => 1]);
+        $existing = Backup::factory()->for($server)->create(['created_at' => CarbonImmutable::now()->subHour()]);
+        $replacement = Backup::factory()->for($server)->create();
+        $attempts = 0;
+
+        $repository = $this->mock(DaemonBackupRepository::class);
+        $repository->allows('setServer')->andReturnSelf();
+        $repository->expects('delete')->times(3)->andReturnUsing(function () use (&$attempts) {
+            $attempts++;
+
+            throw new DaemonConnectionException(
+                new BadResponseException('Deletion failed', new Request('DELETE', '/backup'), new Response(500))
+            );
+        });
+
+        $job = new RotateBackupsJob($server->id, $replacement->id);
+        for ($attempt = 0; $attempt < $job->tries; $attempt++) {
+            try {
+                $job->handle($this->app->make(RotateBackupsService::class));
+            } catch (DaemonConnectionException) {
+                // Laravel marks the job as failed after the third exception.
+            }
+        }
+
+        $this->assertSame(3, $job->tries);
+        $this->assertSame([30, 120], $job->backoff());
+        $this->assertSame(3, $attempts);
+        $this->assertNotSoftDeleted($existing);
+        $this->assertNotSoftDeleted($replacement);
+    }
+}


### PR DESCRIPTION
This PR fixes an issue where if a server could only have one backup and a scheduled backup failed, the server would be left with no usable backups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic backup rotation after successful backup replacements and status retries.
  * Backup cleanup now runs asynchronously, preserving the newly created backup and removing excess unlocked backups when appropriate.
  * Added retry handling for temporary cleanup failures.

* **Bug Fixes**
  * Failed replacement attempts no longer trigger backup rotation or delete existing backups.
  * Locked backups are preserved during cleanup.
  * Rotation respects configured backup limits and avoids unnecessary deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->