### PR TITLE
Fix Server Deletion Order

### DIFF
--- a/app/Services/Servers/ServerDeletionService.php
+++ b/app/Services/Servers/ServerDeletionService.php
@@ -42,15 +42,21 @@ class ServerDeletionService
      */
     public function handle(Server $server): void
     {
-        $this->connection->transaction(function () use ($server) {
-            // Prevent databases from being added while the server is being deleted. Without this
-            // lock, a database created after cleanup could cause the final server deletion to fail.
-            $server = $server->newQuery()
-                ->whereKey($server->getKey())
-                ->lockForUpdate()
-                ->firstOrFail();
+        $databaseIds = $this->connection->transaction(function () use ($server) {
+            $server = $this->lockServer($server);
 
-            foreach ($server->databases as $database) {
+            return $server->databases()->pluck('id');
+        });
+
+        foreach ($databaseIds as $databaseId) {
+            $this->connection->transaction(function () use ($server, $databaseId) {
+                $server = $this->lockServer($server);
+                $database = $server->databases()->find($databaseId);
+
+                if (! $database) {
+                    return;
+                }
+
                 try {
                     $this->databaseManagementService->delete($database);
                 } catch (\Exception $exception) {
@@ -68,6 +74,14 @@ class ServerDeletionService
 
                     Log::warning($exception);
                 }
+            });
+        }
+
+        $this->connection->transaction(function () use ($server) {
+            $server = $this->lockServer($server);
+
+            if ($server->databases()->exists()) {
+                throw new DisplayException('A database was added while this server was being deleted. Please try again.');
             }
 
             try {
@@ -85,5 +99,13 @@ class ServerDeletionService
 
             $server->delete();
         });
+    }
+
+    private function lockServer(Server $server): Server
+    {
+        return $server->newQuery()
+            ->whereKey($server->getKey())
+            ->lockForUpdate()
+            ->firstOrFail();
     }
 }

--- a/app/Services/Servers/ServerDeletionService.php
+++ b/app/Services/Servers/ServerDeletionService.php
@@ -42,21 +42,14 @@ class ServerDeletionService
      */
     public function handle(Server $server): void
     {
-        try {
-            $this->daemonServerRepository->setServer($server)->delete();
-        } catch (DaemonConnectionException $exception) {
-            // If there is an error not caused a 404 error and this isn't a forced delete,
-            // go ahead and bail out. We specifically ignore a 404 since that can be assumed
-            // to be a safe error, meaning the server doesn't exist at all on Agent so there
-            // is no reason we need to bail out from that.
-            if (! $this->force && $exception->getStatusCode() !== Response::HTTP_NOT_FOUND) {
-                throw $exception;
-            }
-
-            Log::warning($exception);
-        }
-
         $this->connection->transaction(function () use ($server) {
+            // Prevent databases from being added while the server is being deleted. Without this
+            // lock, a database created after cleanup could cause the final server deletion to fail.
+            $server = $server->newQuery()
+                ->whereKey($server->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
             foreach ($server->databases as $database) {
                 try {
                     $this->databaseManagementService->delete($database);
@@ -75,6 +68,16 @@ class ServerDeletionService
 
                     Log::warning($exception);
                 }
+            }
+
+            try {
+                $this->daemonServerRepository->setServer($server)->delete();
+            } catch (DaemonConnectionException $exception) {
+                if (! $this->force && $exception->getStatusCode() !== Response::HTTP_NOT_FOUND) {
+                    throw $exception;
+                }
+
+                Log::warning($exception);
             }
 
             // clear any allocation notes for the server

--- a/tests/Integration/Services/Servers/ServerDeletionServiceTest.php
+++ b/tests/Integration/Services/Servers/ServerDeletionServiceTest.php
@@ -117,7 +117,7 @@ class ServerDeletionServiceTest extends IntegrationTestCase
 
         $server->refresh();
 
-        $this->daemonServerRepository->expects('setServer->delete')->withNoArgs()->andReturnUndefined();
+        $this->daemonServerRepository->shouldNotReceive('setServer');
         $this->databaseManagementService->expects('delete')->with(\Mockery::on(function ($value) use ($db) {
             return $value instanceof Database && $value->id === $db->id;
         }))->andThrows(new \Exception());


### PR DESCRIPTION
This PR fixes an issue where, when a server gets deleted, the server is deleted before the database records. This PR switches it around, so the database records are deleted first, since if the database records don't delete, we can easily stop the deletion of the server. Although it's possible that Agent could fail, it's a lot less likely that would happen than the database not working. Sorry for these bad PRs recently; I think I need to get some more sleep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server deletion reliability when database cleanup encounters errors.
  * Prevented daemon removal from proceeding if associated database deletion fails.
  * Reduced the risk of inconsistent cleanup during concurrent server changes.
  * Ensured newly added databases are detected before a server is removed.
  * Improved cleanup consistency by safely handling database deletion and allocation notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->