### PR TITLE
Fix Continue on Failure for Scheduled Tasks

### DIFF
--- a/app/Jobs/Schedule/RunTaskJob.php
+++ b/app/Jobs/Schedule/RunTaskJob.php
@@ -2,7 +2,6 @@
 
 namespace App\Jobs\Schedule;
 
-use App\Exceptions\Http\Connection\DaemonConnectionException;
 use App\Jobs\Job;
 use App\Models\Task;
 use App\Repositories\Agent\DaemonCommandRepository;
@@ -74,9 +73,7 @@ class RunTaskJob extends Job implements ShouldQueue
                     throw new \InvalidArgumentException('Invalid task action provided: '.$this->task->action);
             }
         } catch (Exception $exception) {
-            // If this isn't a DaemonConnectionException on a task that allows for failures
-            // throw the exception back up the chain so that the task is stopped.
-            if (! ($this->task->continue_on_failure && $exception instanceof DaemonConnectionException)) {
+            if (! $this->task->continue_on_failure) {
                 throw $exception;
             }
         }

--- a/tests/Integration/Jobs/Schedule/RunTaskJobTest.php
+++ b/tests/Integration/Jobs/Schedule/RunTaskJobTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Integration\Jobs\Schedule;
 
-use App\Exceptions\Http\Connection\DaemonConnectionException;
 use App\Jobs\Schedule\RunTaskJob;
 use App\Models\Schedule;
 use App\Models\Server;
@@ -10,8 +9,6 @@ use App\Models\Task;
 use App\Repositories\Agent\DaemonPowerRepository;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Bus;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -122,12 +119,10 @@ class RunTaskJobTest extends IntegrationTestCase
         $mock = \Mockery::mock(DaemonPowerRepository::class);
         $this->instance(DaemonPowerRepository::class, $mock);
 
-        $mock->expects('setServer->send')->andThrow(
-            new DaemonConnectionException(new BadResponseException('Bad request', new Request('GET', '/test'), new Response()))
-        );
+        $mock->expects('setServer->send')->andThrow(new \RuntimeException('Task failed.'));
 
         if (! $continueOnFailure) {
-            $this->expectException(DaemonConnectionException::class);
+            $this->expectException(\RuntimeException::class);
         }
 
         Bus::dispatchSync(new RunTaskJob($task));


### PR DESCRIPTION
This PR fixes an issue where tasks would only continue on failure if the failure was related to Agent connection issues. It now continues on all failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled task error handling when “continue on failure” is enabled, allowing processing to continue after task exceptions.
  * Failures are now correctly surfaced when continuation is disabled.

* **Tests**
  * Updated coverage to verify handling of general task failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->