### PR TITLE
Fix Quick Startup Boolean Toggles

### DIFF
--- a/resources/scripts/components/server/startup/VariableBox.tsx
+++ b/resources/scripts/components/server/startup/VariableBox.tsx
@@ -80,12 +80,12 @@ const VariableBox = ({ variable }: Props) => {
                             defaultChecked={
                                 isStringSwitch ? variable.serverValue === 'true' : variable.serverValue === '1'
                             }
-                            onChange={() => {
+                            onChange={(event) => {
                                 if (canEdit && variable.isEditable) {
                                     if (isStringSwitch) {
-                                        setVariableValue(variable.serverValue === 'true' ? 'false' : 'true');
+                                        setVariableValue(event.currentTarget.checked ? 'true' : 'false');
                                     } else {
-                                        setVariableValue(variable.serverValue === '1' ? '0' : '1');
+                                        setVariableValue(event.currentTarget.checked ? '1' : '0');
                                     }
                                 }
                             }}


### PR DESCRIPTION
This PR fixes an issue where toggling the startup switch to quickly would cause it to lag in front of the panel and get into an incorrect/mismatched state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected switch value submission to reflect the current selected state.
  * Boolean switches now submit consistent `true`/`false` values.
  * Numeric switches now submit consistent `1`/`0` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->