### PR TITLE
Fix Hytale Authentication URL

### DIFF
--- a/resources/scripts/components/server/features/HytaleOauthRequireFeature.tsx
+++ b/resources/scripts/components/server/features/HytaleOauthRequireFeature.tsx
@@ -19,8 +19,12 @@ const HytaleOauthRequireFeature = () => {
         if (!connected || !instance || status === 'running') return;
 
         const listener = (line: string) => {
-            if (line.match(/https:\/\/oauth\.accounts\.hytale\.com\/oauth2\/device\/verify\?user_code=(.*)/i)) {
-                setLink(line);
+            const url = line.match(
+                /https:\/\/oauth\.accounts\.hytale\.com\/oauth2\/device\/verify\?user_code=\S+/i
+            )?.[0];
+
+            if (url) {
+                setLink(url);
                 setVisible(true);
             }
         };


### PR DESCRIPTION
This PR fixes an issue where Hytale OAuth URLs open incorrectly.

Something I want to point out, though, is that this seems to have been added from Pterodactyl, but we don't actually have a default egg for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hytale OAuth verification handling by extracting and storing only the verification URL from matching console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->