### PR TITLE
Fix Activity Log Filter Pagination

### DIFF
--- a/resources/scripts/components/dashboard/activity/ActivityLogContainer.tsx
+++ b/resources/scripts/components/dashboard/activity/ActivityLogContainer.tsx
@@ -25,7 +25,7 @@ export default () => {
     });
 
     useEffect(() => {
-        setFilters((value) => ({ ...value, filters: { ip: hash.ip, event: hash.event } }));
+        setFilters((value) => ({ ...value, page: 1, filters: { ip: hash.ip, event: hash.event } }));
     }, [hash]);
 
     useEffect(() => {
@@ -40,7 +40,7 @@ export default () => {
                     <Link
                         to={'#'}
                         className={classNames(btnStyles.button, btnStyles.text, 'w-full sm:w-auto')}
-                        onClick={() => setFilters((value) => ({ ...value, filters: {} }))}
+                        onClick={() => setFilters((value) => ({ ...value, page: 1, filters: {} }))}
                     >
                         {t('activity.clear-filters')} <XCircleIcon className={'w-4 h-4 ml-2'} />
                     </Link>

--- a/resources/scripts/components/server/ServerActivityLogContainer.tsx
+++ b/resources/scripts/components/server/ServerActivityLogContainer.tsx
@@ -26,7 +26,7 @@ export default () => {
     });
 
     useEffect(() => {
-        setFilters((value) => ({ ...value, filters: { ip: hash.ip, event: hash.event } }));
+        setFilters((value) => ({ ...value, page: 1, filters: { ip: hash.ip, event: hash.event } }));
     }, [hash]);
 
     useEffect(() => {
@@ -41,7 +41,7 @@ export default () => {
                     <Link
                         to={'#'}
                         className={classNames(btnStyles.button, btnStyles.text, 'w-full sm:w-auto')}
-                        onClick={() => setFilters((value) => ({ ...value, filters: {} }))}
+                        onClick={() => setFilters((value) => ({ ...value, page: 1, filters: {} }))}
                     >
                         Clear Filters <XCircleIcon className={'w-4 h-4 ml-2'} />
                     </Link>


### PR DESCRIPTION
This PR fixes an issue where if you are in a client activity log with the page greater than one and set it to a filter with the results taking less than one page it would show no results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity logs now return to page 1 when filters are applied from a URL or cleared.
  * Updated behavior applies consistently across dashboard and server activity logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->