### PR TITLE
Make Allocation Blur Look Better

### DIFF
--- a/resources/scripts/components/server/console/StatBlock.tsx
+++ b/resources/scripts/components/server/console/StatBlock.tsx
@@ -28,8 +28,8 @@ export default ({ title, copyOnClick, icon, color, className, children }: StatBl
                         })}
                     />
                 </div>
-                <div className={'flex flex-col justify-center overflow-hidden w-full'}>
-                    <p className={'font-header leading-tight text-xs md:text-sm text-gray-200'}>{title}</p>
+                <div className={'flex flex-col justify-center min-w-0 w-full'}>
+                    <p className={'font-header leading-tight text-xs md:text-sm text-gray-200 truncate'}>{title}</p>
                     <div className={'h-[1.75rem] w-full font-semibold text-gray-50 text-xl'}>{children}</div>
                 </div>
             </div>

--- a/resources/scripts/reviactyl/ui/Blur.tsx
+++ b/resources/scripts/reviactyl/ui/Blur.tsx
@@ -12,7 +12,11 @@ export default function Blur({ className = '', children, ...rest }: BlurProps) {
     return (
         <span
             {...rest}
-            className={`${allocationBlur ? 'duration-300 blur-sm hover:blur-none' : 'blur-none'} ${className}`}
+            className={`${
+                allocationBlur
+                    ? 'blur-sm transition-[filter] duration-250 ease-out hover:blur-none motion-reduce:transition-none'
+                    : 'blur-none'
+            } inline-block max-w-full truncate align-bottom ${className}`}
         >
             {children}
         </span>


### PR DESCRIPTION
This PR makes the allocation blur look a lot better by fading the edges a bit more rather than having the weird rectangle cutout. Because I'm horrible at describing things, I've attached before-and-after photos. This also closes #493.

Before:
<img width="598" height="218" alt="before1" src="https://github.com/user-attachments/assets/a2af7105-24b3-4f20-ad3d-f524f0384c45" />

After:
<img width="588" height="214" alt="after1" src="https://github.com/user-attachments/assets/e1221464-5666-4e78-8022-490bfa9e3fa6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server console stat layouts so long titles and content remain contained without disrupting surrounding elements.
  * Updated allocation blur behavior with smoother transitions, improved text alignment and truncation, and better support for reduced-motion preferences.
  * Preserved hover-based blur removal while refining the visual presentation of blurred content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->