### PR TITLE
Improve Server Search Functionality

### DIFF
--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -26,6 +26,7 @@ import { Button } from '@/reviactyl/components/button';
 import { FaUserGear } from 'react-icons/fa6';
 import { ExtensionSlot } from '@/extensions/ExtensionSlot';
 import { useSubuserPreview } from '@/context/SubuserPreviewContext';
+import SearchContainer from '@/components/dashboard/search/SearchContainer';
 
 export default () => {
     const { t } = useTranslation('dashboard/index');
@@ -36,6 +37,7 @@ export default () => {
     const { clearFlashes, clearAndAddHttpError } = useFlash();
     const uuid = useStoreState((state) => state.user.data!.uuid);
     const accountRootAdmin = useStoreState((state) => state.user.data!.rootAdmin);
+    const layoutType = useStoreState((state) => state.designify.data!.layoutType);
     const { session } = useSubuserPreview();
     const rootAdmin = accountRootAdmin && !session;
     const [showOnlyAdmin, setShowOnlyAdmin] = usePersistedState(`${uuid}:show_all_servers`, false);
@@ -167,6 +169,11 @@ export default () => {
                 {!session && (
                     <div className='flex flex-col sm:flex-row items-stretch sm:items-center gap-4 w-full md:w-auto'>
                         <div className='flex flex-row items-center justify-between sm:justify-start gap-4 sm:gap-0 w-full sm:w-auto sm:space-x-4'>
+                            {layoutType === 'modern' && (
+                                <div className='w-full sm:w-auto'>
+                                    <SearchContainer />
+                                </div>
+                            )}
                             {rootAdmin && (
                                 <div className={`flex flex-shrink-0 items-center justify-between gap-2`}>
                                     <p className='uppercase text-xs text-gray-300 whitespace-nowrap'>

--- a/resources/scripts/components/dashboard/search/SearchModal.tsx
+++ b/resources/scripts/components/dashboard/search/SearchModal.tsx
@@ -1,14 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
-import Modal, { RequiredModalProps } from '@/reviactyl/elements/Modal';
-import { Field, Form, Formik, FormikHelpers, useFormikContext } from 'formik';
-import { Actions, useStoreActions, useStoreState } from 'easy-peasy';
-import { object, string } from 'yup';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Modal from '@/reviactyl/elements/Modal';
+import type { RequiredModalProps } from '@/reviactyl/elements/Modal';
+import { Field, Form, Formik, useFormikContext } from 'formik';
+import { useStoreActions, useStoreState } from 'easy-peasy';
+import type { Actions } from 'easy-peasy';
 import debounce from 'debounce';
+import { object, string } from 'yup';
 import FormikFieldWrapper from '@/reviactyl/elements/FormikFieldWrapper';
 import InputSpinner from '@/reviactyl/elements/InputSpinner';
 import getServers from '@/api/getServers';
-import { Server } from '@/api/server/getServer';
-import { ApplicationStore } from '@/state';
+import type { Server } from '@/api/server/getServer';
+import type { ApplicationStore } from '@/state';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import tw from 'twin.macro';
@@ -34,14 +36,19 @@ const ServerResult = styled(Link)`
     }
 `;
 
-const SearchWatcher = () => {
-    const { values, submitForm } = useFormikContext<Values>();
+interface SearchWatcherProps {
+    onTermChanged: (term: string, setSubmitting: (submitting: boolean) => void) => void;
+}
+
+const SearchWatcher = ({ onTermChanged }: SearchWatcherProps) => {
+    const { values, setFieldTouched, setSubmitting } = useFormikContext<Values>();
 
     useEffect(() => {
-        if (values.term.length >= 3) {
-            submitForm();
+        if (values.term.length > 0) {
+            void setFieldTouched('term', true, true);
         }
-    }, [values.term]);
+        onTermChanged(values.term, setSubmitting);
+    }, [values.term, onTermChanged, setFieldTouched, setSubmitting]);
 
     return null;
 };
@@ -49,25 +56,66 @@ const SearchWatcher = () => {
 export default ({ ...props }: Props) => {
     const { t } = useTranslation('dashboard/index');
     const ref = useRef<HTMLInputElement>(null);
+    const searchGeneration = useRef(0);
     const isAdmin = useStoreState((state) => state.user.data!.rootAdmin);
     const [servers, setServers] = useState<Server[]>([]);
     const { clearAndAddHttpError, clearFlashes } = useStoreActions(
         (actions: Actions<ApplicationStore>) => actions.flashes
     );
 
-    const search = debounce(({ term }: Values, { setSubmitting }: FormikHelpers<Values>) => {
-        clearFlashes('search');
+    const search = useMemo(
+        () =>
+            debounce((term: string, generation: number, setSubmitting: (submitting: boolean) => void) => {
+                clearFlashes('search');
 
-        // if (ref.current) ref.current.focus();
-        getServers({ query: term, type: isAdmin ? 'admin-all' : undefined })
-            .then((servers) => setServers(servers.items.filter((_, index) => index < 5)))
-            .catch((error) => {
-                console.error(error);
-                clearAndAddHttpError({ key: 'search', error });
-            })
-            .then(() => setSubmitting(false))
-            .then(() => ref.current?.focus());
-    }, 500);
+                // if (ref.current) ref.current.focus();
+                getServers({ query: term, type: isAdmin ? 'admin-all' : undefined })
+                    .then((response) => {
+                        if (generation === searchGeneration.current) {
+                            setServers(response.items.filter((_, index) => index < 5));
+                        }
+                    })
+                    .catch((error) => {
+                        if (generation === searchGeneration.current) {
+                            console.error(error);
+                            clearAndAddHttpError({ key: 'search', error });
+                        }
+                    })
+                    .then(() => {
+                        if (generation === searchGeneration.current) {
+                            setSubmitting(false);
+                            ref.current?.focus();
+                        }
+                    });
+            }, 500),
+        [clearAndAddHttpError, clearFlashes, isAdmin]
+    );
+
+    const onTermChanged = useCallback(
+        (term: string, setSubmitting: (submitting: boolean) => void) => {
+            const generation = ++searchGeneration.current;
+
+            search.clear();
+            setServers([]);
+
+            if (term.length < 3) {
+                setSubmitting(false);
+                return;
+            }
+
+            setSubmitting(true);
+            search(term, generation, setSubmitting);
+        },
+        [search]
+    );
+
+    useEffect(
+        () => () => {
+            searchGeneration.current++;
+            search.clear();
+        },
+        [search]
+    );
 
     useEffect(() => {
         if (props.visible) {
@@ -80,7 +128,7 @@ export default ({ ...props }: Props) => {
 
     return (
         <Formik
-            onSubmit={search}
+            onSubmit={() => undefined}
             validationSchema={object().shape({
                 term: string().min(3, t('search.string-min')),
             })}
@@ -94,7 +142,7 @@ export default ({ ...props }: Props) => {
                             label={t('search.form-label')}
                             description={t('search.form-description')}
                         >
-                            <SearchWatcher />
+                            <SearchWatcher onTermChanged={onTermChanged} />
                             <InputSpinner visible={isSubmitting}>
                                 <Field as={InputWithRef} name={'term'} />
                             </InputSpinner>

--- a/resources/scripts/components/dashboard/search/SearchModal.tsx
+++ b/resources/scripts/components/dashboard/search/SearchModal.tsx
@@ -128,7 +128,7 @@ export default ({ ...props }: Props) => {
 
     return (
         <Formik
-            onSubmit={() => undefined}
+            onSubmit={() => Promise.resolve()}
             validationSchema={object().shape({
                 term: string().min(3, t('search.string-min')),
             })}


### PR DESCRIPTION
This PR makes the server search bar clear results when the search is under 3 characters and adds the search bar into the modern view screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added search controls to dashboards using the modern layout, except during subuser preview sessions.
  - Searches now begin automatically, after a short delay, when at least three characters are entered.

- **Bug Fixes**
  - Improved search results by clearing outdated results and ignoring responses from older searches.
  - Improved loading-state handling and restored focus to the search field after searching.
  - Pending searches are now canceled when the search window is closed.
  - Improved form behavior after searches complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->