### PR TITLE
Prevent OAuth accounts from auto-linking by email

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Manage Game Servers like Never Before!
 
 ## Features
 
-* ` 🌩️ ` **Customizable Options**: Reviactyl offers various* options that lets you customize the panel to your liking.
-* ` 🎨 ` **Client-side Theme Selector**: Let your clients' choose between various styles according to their liking.
+* ` 🌩️ ` **Customizable Options**: Reviactyl offers various options that let you customize the panel to your liking.
+* ` 🎨 ` **Client-side Theme Selector**: Let your clients choose between various styles according to their preferences.
 * ` 🖥️ ` **Modern UI**: Reviactyl offers a modern and sleek UI that's more accessible than other modifications on market.
 * ` 🌍 ` **Multilingual**: Reviactyl is fully translatable and can be localized to your native language.
 * ` 🧩 ` **Extensions API**: ( Planned, check [#200](https://github.com/reviactyl/panel/discussions/200) for updates on this. )
-* ` 📦 ` **Modern Software**: Reviactyl is built with Laravel 12, Filament v5, React v19 Vite for User Dashboard.
+* ` 📦 ` **Modern Software**: Reviactyl is built with Laravel 12, Filament v5, React 19, and Vite for the user dashboard.
 * ` 🔋 ` **Batteries Included**: Reviactyl has most of core features built-in, which means there's no need of spending money for basic features.
 * ` 🍀 ` **Open Source & Free**: Reviactyl is the free open-source game server management panel built upon Pterodactyl offering modern codebase, security, & improvements.
 

--- a/app/Http/Controllers/Auth/SocialLoginController.php
+++ b/app/Http/Controllers/Auth/SocialLoginController.php
@@ -3,14 +3,11 @@
 namespace App\Http\Controllers\Auth;
 
 use Exception;
-use App\Models\User;
 use Illuminate\Support\Str;
 use App\Models\SocialLogin;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
 use Laravel\Socialite\Facades\Socialite;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\DB;
 
 class SocialLoginController extends Controller
 {
@@ -84,22 +81,8 @@ class SocialLoginController extends Controller
             return redirect('/');
         }
 
-        // Check if user with email exists (Auto-Link)
-        $user = User::where('email', $socialUser->getEmail())->first();
-
-        if ($user) {
-            // Link account automatically if email matches
-            $user->socialLogins()->create([
-                'provider' => $provider,
-                'provider_user_id' => $socialUser->getId(),
-                'provider_token' => $socialUser->token,
-                'provider_refresh_token' => $socialUser->refreshToken,
-            ]);
-
-            Auth::login($user);
-            return redirect('/');
-        }
-
+        // Never link an OAuth identity by email alone. The account owner must
+        // authenticate locally before linking a new provider.
         return redirect()->route('auth.login')->with('error', trans('auth.social.not_linked', ['provider' => ucfirst($provider)]));
     }
 


### PR DESCRIPTION
## Summary
- remove automatic OAuth account linking based only on matching email addresses
- require users to authenticate locally before linking a new provider
- remove unused controller imports

## Security impact
An unlinked OAuth identity can no longer be used to sign in to an existing local account by presenting a matching email address. Existing provider-ID links and explicit authenticated-account linking are unchanged.

## Validation
- `git diff --check` passed
- PHP syntax/tests could not run because PHP and Composer are unavailable in the environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Authentication**
  - Social login no longer automatically links an OAuth identity to an existing account based solely on email matching.
  - Unlinked social identities now receive the existing “not linked” error response.

- **Documentation**
  - Updated feature descriptions for customizable options, client-side theme selection, and the technology used for the user dashboard.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->