### PR TITLE
Fix bulk server deletion

### DIFF
--- a/app/Filament/Resources/Nodes/RelationManagers/ServersRelationManager.php
+++ b/app/Filament/Resources/Nodes/RelationManagers/ServersRelationManager.php
@@ -2,9 +2,8 @@
 
 namespace App\Filament\Resources\Nodes\RelationManagers;
 
-use App\Models\Allocation;
 use App\Models\Server;
-use App\Services\Allocations\AllocationDeletionService;
+use App\Services\Servers\ServerDeletionService;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -12,6 +11,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Throwable;
 
 class ServersRelationManager extends RelationManager
 {
@@ -73,18 +73,21 @@ class ServersRelationManager extends RelationManager
                         ->label(trans('admin/server.actions.delete'))
                         ->icon('heroicon-o-trash')
                         ->requiresConfirmation()
-                        ->action(function (Collection $records) {
-                            $records->each(function ($record): void {
+                        ->using(function (DeleteBulkAction $action, Collection $records): void {
+                            foreach ($records as $record) {
                                 if (! $record instanceof Server) {
-                                    return;
+                                    $action->reportBulkProcessingFailure();
+
+                                    continue;
                                 }
 
-                                if ($record->allocation instanceof Allocation) {
-                                    app(AllocationDeletionService::class)->handle($record->allocation);
+                                try {
+                                    app(ServerDeletionService::class)->withForce(false)->handle($record);
+                                } catch (Throwable $exception) {
+                                    $action->reportBulkProcessingFailure();
+                                    report($exception);
                                 }
-
-                                $record->delete();
-                            });
+                            }
                         }),
                 ]),
             ]);

--- a/app/Filament/Resources/Servers/Tables/ServersTable.php
+++ b/app/Filament/Resources/Servers/Tables/ServersTable.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\Servers\Tables;
 
 use App\Models\Server;
+use App\Services\Servers\ServerDeletionService;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -13,6 +14,8 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Throwable;
 
 class ServersTable
 {
@@ -164,6 +167,22 @@ class ServersTable
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make()
+                        ->using(function (DeleteBulkAction $action, Collection $records): void {
+                            foreach ($records as $record) {
+                                if (! $record instanceof Server) {
+                                    $action->reportBulkProcessingFailure();
+
+                                    continue;
+                                }
+
+                                try {
+                                    app(ServerDeletionService::class)->withForce(false)->handle($record);
+                                } catch (Throwable $exception) {
+                                    $action->reportBulkProcessingFailure();
+                                    report($exception);
+                                }
+                            }
+                        })
                         ->label(trans('admin/server.actions.delete')),
                 ]),
             ]);

--- a/app/Filament/Resources/Users/RelationManagers/ServersRelationManager.php
+++ b/app/Filament/Resources/Users/RelationManagers/ServersRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\Users\RelationManagers;
 
 use App\Models\Server;
+use App\Services\Servers\ServerDeletionService;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
@@ -11,7 +12,9 @@ use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Throwable;
 
 class ServersRelationManager extends RelationManager
 {
@@ -134,6 +137,22 @@ class ServersRelationManager extends RelationManager
             ->bulkActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make()
+                        ->using(function (DeleteBulkAction $action, Collection $records): void {
+                            foreach ($records as $record) {
+                                if (! $record instanceof Server) {
+                                    $action->reportBulkProcessingFailure();
+
+                                    continue;
+                                }
+
+                                try {
+                                    app(ServerDeletionService::class)->withForce(false)->handle($record);
+                                } catch (Throwable $exception) {
+                                    $action->reportBulkProcessingFailure();
+                                    report($exception);
+                                }
+                            }
+                        })
                         ->label(trans('admin/server.actions.delete'))
                         ->requiresConfirmation(),
                 ]),

--- a/tests/Integration/Services/Servers/ServerDeletionServiceTest.php
+++ b/tests/Integration/Services/Servers/ServerDeletionServiceTest.php
@@ -3,14 +3,19 @@
 namespace Tests\Integration\Services\Servers;
 
 use App\Exceptions\Http\Connection\DaemonConnectionException;
+use App\Filament\Resources\Servers\Tables\ServersTable;
+use App\Filament\Resources\Users\RelationManagers\ServersRelationManager;
 use App\Models\Database;
 use App\Models\DatabaseHost;
 use App\Repositories\Agent\DaemonServerRepository;
 use App\Services\Databases\DatabaseManagementService;
 use App\Services\Servers\ServerDeletionService;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Illuminate\Database\Eloquent\Collection;
 use Mockery\MockInterface;
 use Tests\Integration\IntegrationTestCase;
 
@@ -156,5 +161,70 @@ class ServerDeletionServiceTest extends IntegrationTestCase
     private function getService(): ServerDeletionService
     {
         return $this->app->make(ServerDeletionService::class);
+    }
+
+    public function test_all_server_bulk_actions_clean_up_remote_resources(): void
+    {
+        foreach ($this->serverBulkActions() as $action) {
+            $server = $this->createServerModel();
+            $allocation = $server->allocation;
+            $allocation->update(['notes' => 'remove on deletion']);
+            $host = DatabaseHost::factory()->create();
+            $database = Database::factory()->create(['database_host_id' => $host->id, 'server_id' => $server->id]);
+
+            $this->databaseManagementService->expects('delete')
+                ->with(\Mockery::on(fn ($record) => $record->id === $database->id))
+                ->andReturnUsing(function ($record) use ($server): void {
+                    $this->assertDatabaseHas('servers', ['id' => $server->id]);
+                    $record->delete();
+                });
+            $this->daemonServerRepository->expects('setServer')
+                ->with(\Mockery::on(fn ($record) => $record->id === $server->id))
+                ->andReturnSelf();
+            $this->daemonServerRepository->expects('delete')->andReturnUsing(function () use ($server, $database): void {
+                $this->assertDatabaseMissing('databases', ['id' => $database->id]);
+                $this->assertDatabaseHas('servers', ['id' => $server->id]);
+            });
+
+            $action->process(null, ['records' => new Collection([$server])]);
+
+            $this->assertDatabaseMissing('servers', ['id' => $server->id]);
+            $this->assertDatabaseHas('allocations', ['id' => $allocation->id, 'server_id' => null, 'notes' => null]);
+        }
+    }
+
+    public function test_all_server_bulk_actions_retain_failed_servers_and_continue(): void
+    {
+        foreach ($this->serverBulkActions() as $action) {
+            $failed = $this->createServerModel();
+            $successful = $this->createServerModel();
+            $this->daemonServerRepository->expects('setServer')
+                ->with(\Mockery::on(fn ($record) => $record->id === $failed->id))
+                ->andReturnSelf();
+            $this->daemonServerRepository->expects('delete')->andThrow(
+                new DaemonConnectionException(new BadResponseException('Unavailable', new Request('DELETE', '/test'), new Response(500)))
+            );
+            $this->daemonServerRepository->expects('setServer')
+                ->with(\Mockery::on(fn ($record) => $record->id === $successful->id))
+                ->andReturnSelf();
+            $this->daemonServerRepository->expects('delete')->andReturnUndefined();
+
+            $action->process(null, ['records' => new Collection([$failed, $successful])]);
+
+            $this->assertDatabaseHas('servers', ['id' => $failed->id]);
+            $this->assertDatabaseMissing('servers', ['id' => $successful->id]);
+            $this->assertSame(1, (new \ReflectionProperty($action, 'bulkProcessingFailureWithoutMessageCount'))->getValue($action));
+        }
+    }
+
+    private function serverBulkActions(): array
+    {
+        $livewire = \Mockery::mock(HasTable::class)->shouldIgnoreMissing();
+
+        return [
+            ServersTable::configure(Table::make($livewire))->getBulkAction('delete'),
+            (new ServersRelationManager())->table(Table::make($livewire))->getBulkAction('delete'),
+            (new \App\Filament\Resources\Nodes\RelationManagers\ServersRelationManager())->table(Table::make($livewire))->getBulkAction('delete'),
+        ];
     }
 }


### PR DESCRIPTION
This PR fixes an issue where bulk deleting a server wouldn't end up deleting it from Agent. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bulk server deletion across server lists and node/user server views.
  - Related allocations and remote resources are now cleaned up consistently during deletion.
  - A failed deletion no longer stops the remaining selected servers from being processed.
  - Failed records are retained and surfaced for review, while successful deletions continue normally.

- **Tests**
  - Added coverage for successful bulk deletion, resource cleanup, failure handling, and continued processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->