### PR TITLE
Prevent OAuth accounts from auto-linking by email

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Manage Game Servers like Never Before!
 
 ## Features
 
-* ` 🌩️ ` **Customizable Options**: Reviactyl offers various* options that lets you customize the panel to your liking.
-* ` 🎨 ` **Client-side Theme Selector**: Let your clients' choose between various styles according to their liking.
+* ` 🌩️ ` **Customizable Options**: Reviactyl offers various options that let you customize the panel to your liking.
+* ` 🎨 ` **Client-side Theme Selector**: Let your clients choose between various styles according to their preferences.
 * ` 🖥️ ` **Modern UI**: Reviactyl offers a modern and sleek UI that's more accessible than other modifications on market.
 * ` 🌍 ` **Multilingual**: Reviactyl is fully translatable and can be localized to your native language.
 * ` 🧩 ` **Extensions API**: ( Planned, check [#200](https://github.com/reviactyl/panel/discussions/200) for updates on this. )
-* ` 📦 ` **Modern Software**: Reviactyl is built with Laravel 12, Filament v5, React v19 Vite for User Dashboard.
+* ` 📦 ` **Modern Software**: Reviactyl is built with Laravel 12, Filament v5, React 19, and Vite for the user dashboard.
 * ` 🔋 ` **Batteries Included**: Reviactyl has most of core features built-in, which means there's no need of spending money for basic features.
 * ` 🍀 ` **Open Source & Free**: Reviactyl is the free open-source game server management panel built upon Pterodactyl offering modern codebase, security, & improvements.
 

--- a/app/Http/Controllers/Auth/SocialLoginController.php
+++ b/app/Http/Controllers/Auth/SocialLoginController.php
@@ -3,14 +3,11 @@
 namespace App\Http\Controllers\Auth;
 
 use Exception;
-use App\Models\User;
 use Illuminate\Support\Str;
 use App\Models\SocialLogin;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
 use Laravel\Socialite\Facades\Socialite;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\DB;
 
 class SocialLoginController extends Controller
 {
@@ -84,22 +81,8 @@ class SocialLoginController extends Controller
             return redirect('/');
         }
 
-        // Check if user with email exists (Auto-Link)
-        $user = User::where('email', $socialUser->getEmail())->first();
-
-        if ($user) {
-            // Link account automatically if email matches
-            $user->socialLogins()->create([
-                'provider' => $provider,
-                'provider_user_id' => $socialUser->getId(),
-                'provider_token' => $socialUser->token,
-                'provider_refresh_token' => $socialUser->refreshToken,
-            ]);
-
-            Auth::login($user);
-            return redirect('/');
-        }
-
+        // Never link an OAuth identity by email alone. The account owner must
+        // authenticate locally before linking a new provider.
         return redirect()->route('auth.login')->with('error', trans('auth.social.not_linked', ['provider' => ucfirst($provider)]));
     }
 

--- a/app/Http/Controllers/Auth/SocialLoginController.php
+++ b/app/Http/Controllers/Auth/SocialLoginController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Auth;
 
 use Exception;
-use Illuminate\Support\Str;
 use App\Models\SocialLogin;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
@@ -84,24 +83,6 @@ class SocialLoginController extends Controller
         // Never link an OAuth identity by email alone. The account owner must
         // authenticate locally before linking a new provider.
         return redirect()->route('auth.login')->with('error', trans('auth.social.not_linked', ['provider' => ucfirst($provider)]));
-    }
-
-    protected function generateUsername(string $name): string
-    {
-        $base = Str::slug($name);
-        if (empty($base)) {
-            $base = 'user';
-        }
-
-        $username = $base;
-        $counter = 1;
-
-        while (User::where('username', $username)->exists()) {
-            $username = $base . $counter;
-            $counter++;
-        }
-
-        return $username;
     }
 
     protected function configureDriver(string $provider): bool


### PR DESCRIPTION
## Summary
- remove guest OAuth auto-linking based only on matching email addresses
- require an existing provider identity or an authenticated account-linking flow
- remove the obsolete username-generation helper

## Security
An unlinked OAuth identity must not be able to authenticate as an existing local account by presenting a matching email address. This change preserves existing provider-ID login and explicit authenticated linking while preventing that account-takeover path.

Please review this as a security fix. I can provide reproduction details privately if needed.

## Validation
- `git diff --check` passed
- PHP tests could not run because PHP and Composer are unavailable in the environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Authentication**
  - Social logins that are not already linked to an account now redirect to the login page with an error instead of automatically creating an account and signing the user in.

- **Documentation**
  - Updated feature descriptions and technology stack details for improved clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->