### PR TITLE
Fix FQDN validation for nodes

### DIFF
--- a/app/Filament/Resources/Nodes/Schemas/CreateNodeForm.php
+++ b/app/Filament/Resources/Nodes/Schemas/CreateNodeForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Nodes\Schemas;
 
+use App\Rules\NodeFqdn;
 use App\Services\Helpers\RandomWordService;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
@@ -163,6 +164,7 @@ class CreateNodeForm
                             Grid::make()
                                 ->schema([
                                     TextInput::make('fqdn')
+                                        ->rules([new NodeFqdn()])
                                         ->label(trans('admin/node.fields.fqdn.label'))
                                         ->required()
                                         ->maxLength(255)

--- a/app/Filament/Resources/Nodes/Schemas/EditNodeForm.php
+++ b/app/Filament/Resources/Nodes/Schemas/EditNodeForm.php
@@ -6,6 +6,7 @@ use App\Models\ApiKey;
 use App\Models\Node;
 use App\Repositories\Agent\DaemonConfigurationRepository;
 use App\Repositories\Agent\DaemonMonitoringRepository;
+use App\Rules\NodeFqdn;
 use App\Services\Api\KeyCreationService;
 use App\Services\Helpers\SoftwareVersionService;
 use Filament\Actions\Action;
@@ -385,6 +386,7 @@ class EditNodeForm
                                     ->description(trans('admin/node.sections.connection.description'))
                                     ->schema([
                                         TextInput::make('fqdn')
+                                            ->rules([new NodeFqdn()])
                                             ->label(trans('admin/node.fields.fqdn.label'))
                                             ->required()
                                             ->maxLength(255)

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -150,7 +150,12 @@ class Node extends Model implements Identifiable
      */
     public function getConnectionAddress(): string
     {
-        return sprintf('%s://%s:%s', $this->scheme, $this->fqdn, $this->daemonListen);
+        $host = $this->fqdn;
+        if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            $host = '['.$host.']';
+        }
+
+        return sprintf('%s://%s:%s', $this->scheme, $host, $this->daemonListen);
     }
 
     /**

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Contracts\Models\Identifiable;
 use App\Exceptions\DisplayException;
 use App\Models\Traits\HasRealtimeIdentifier;
+use App\Rules\NodeFqdn;
 use Carbon\Carbon;
 use Database\Factories\NodeFactory;
 use Illuminate\Container\Container;
@@ -135,6 +136,14 @@ class Node extends Model implements Identifiable
         'daemonListen' => 8080,
         'maintenance_mode' => false,
     ];
+
+    public static function getRules(): array
+    {
+        $rules = parent::getRules();
+        $rules['fqdn'][] = new NodeFqdn();
+
+        return $rules;
+    }
 
     /**
      * Get the connection address to use when making calls to this node.

--- a/app/Rules/NodeFqdn.php
+++ b/app/Rules/NodeFqdn.php
@@ -2,11 +2,19 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class NodeFqdn implements Rule
+class NodeFqdn implements ValidationRule
 {
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $this->isValidHost($value)) {
+            $fail('The :attribute must be a hostname or IP address without a scheme, port, or path.');
+        }
+    }
+
+    private function isValidHost(mixed $value): bool
     {
         if (! is_string($value) || $value === '') {
             return false;
@@ -22,10 +30,5 @@ class NodeFqdn implements Rule
         }
 
         return (bool) filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
-    }
-
-    public function message(): string
-    {
-        return 'The :attribute must be a hostname or IP address without a scheme, port, or path.';
     }
 }

--- a/app/Rules/NodeFqdn.php
+++ b/app/Rules/NodeFqdn.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class NodeFqdn implements Rule
+{
+    public function passes($attribute, $value): bool
+    {
+        if (! is_string($value) || $value === '') {
+            return false;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_IP)) {
+            return true;
+        }
+
+        // Brackets are valid around an IPv6 host in a connection address.
+        if (str_starts_with($value, '[') && str_ends_with($value, ']')) {
+            return (bool) filter_var(substr($value, 1, -1), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
+        }
+
+        return (bool) filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+    }
+
+    public function message(): string
+    {
+        return 'The :attribute must be a hostname or IP address without a scheme, port, or path.';
+    }
+}

--- a/tests/Unit/Models/NodeTest.php
+++ b/tests/Unit/Models/NodeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Node;
+use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class NodeTest extends TestCase
+{
+    #[DataProvider('connectionHosts')]
+    public function test_connection_address_preserves_host_and_port(string $fqdn, string $host): void
+    {
+        foreach (['http', 'https'] as $scheme) {
+            $node = new Node(['fqdn' => $fqdn, 'scheme' => $scheme, 'daemonListen' => 8080]);
+
+            $address = $node->getConnectionAddress();
+            $this->assertSame($scheme.'://'.$host.':8080', $address);
+
+            $uri = new Uri($address);
+            $this->assertSame($host, $uri->getHost());
+            $this->assertSame(8080, $uri->getPort());
+        }
+    }
+
+    public static function connectionHosts(): array
+    {
+        return [
+            ['node.example.com', 'node.example.com'],
+            ['192.0.2.1', '192.0.2.1'],
+            ['2001:db8::1', '[2001:db8::1]'],
+            ['[2001:db8::1]', '[2001:db8::1]'],
+            ['::1', '[::1]'],
+            ['::ffff:192.0.2.1', '[::ffff:192.0.2.1]'],
+        ];
+    }
+}

--- a/tests/Unit/Rules/NodeFqdnTest.php
+++ b/tests/Unit/Rules/NodeFqdnTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Rules;
+
+use App\Models\Node;
+use Illuminate\Translation\ArrayLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class NodeFqdnTest extends TestCase
+{
+    #[DataProvider('hosts')]
+    public function test_node_validation_requires_a_host(mixed $host, bool $valid): void
+    {
+        $factory = new Factory(new Translator(new ArrayLoader(), 'en'));
+
+        foreach ([Node::getRulesForField('fqdn'), Node::getRulesForUpdate(1)['fqdn']] as $rules) {
+            $validator = $factory->make(['fqdn' => $host], ['fqdn' => $rules]);
+
+            $this->assertSame($valid, $validator->passes());
+        }
+    }
+
+    public static function hosts(): array
+    {
+        return [
+            ['node.example.com', true],
+            ['node-1.example.com', true],
+            ['node.example.com.', true],
+            ['localhost', true],
+            ['192.0.2.1', true],
+            ['2001:db8::1', true],
+            ['[2001:db8::1]', true],
+            ['https://node.example.com', false],
+            ['http://node.example.com', false],
+            ['//node.example.com', false],
+            ['node.example.com:8080', false],
+            ['[2001:db8::1]:8080', false],
+            ['node.example.com/path', false],
+            ['node.example.com?query=1', false],
+            ['node.example.com#fragment', false],
+            ['user@node.example.com', false],
+            ['node.example.com\\path', false],
+            ['node example.com', false],
+            [' node.example.com', false],
+            ['node.example.com\n', false],
+            ['-node.example.com', false],
+            ['', false],
+            [null, false],
+            [123, false],
+            [['node.example.com'], false],
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds proper input validation in node creation. Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for node connection addresses during creation and editing.
  - Node addresses now support valid hostnames, IPv4 addresses, IPv6 addresses, and localhost values.
  - Bracketed IPv6 values are supported and formatted correctly in connection addresses.

- **Bug Fixes**
  - Invalid addresses containing schemes, ports, paths, whitespace, or malformed values are now rejected.
  - IPv6 connection addresses now use the correct bracketed format when combined with a port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->