### PR TITLE
Keep console tab visible in compact and accent layouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,17 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v4
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: intl, mbstring, pdo, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist --no-scripts
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.3'
           extensions: intl, mbstring, pdo, zip

--- a/resources/scripts/reviactyl/components/layouts/SidebarAccent.tsx
+++ b/resources/scripts/reviactyl/components/layouts/SidebarAccent.tsx
@@ -41,9 +41,9 @@ export const SidebarAccent = React.forwardRef<HTMLDivElement, SidebarProps>(({ c
     return (
         <div
             ref={ref}
-            className={`w-[225px] self-start flex-col bg-gray-900 text-white transition-transform duration-300 ease-in-out 2xl:w-64 lg:fixed lg:top-[var(--subuser-preview-offset,0px)] lg:left-0 lg:z-40 lg:flex lg:h-[calc(100dvh-var(--subuser-preview-offset,0px))] lg:overflow-y-auto lg:bg-transparent ${
+            className={`w-[225px] self-start flex-col bg-gray-900 text-white transition-transform duration-300 ease-in-out 2xl:w-64 lg:fixed lg:top-[calc(4rem+var(--subuser-preview-offset,0px))] lg:left-0 lg:z-40 lg:flex lg:h-[calc(100dvh-4rem-var(--subuser-preview-offset,0px))] lg:overflow-y-auto lg:bg-transparent ${
                 isOpen
-                    ? 'fixed top-[calc(4rem+var(--subuser-preview-offset,0px))] left-0 z-40 flex h-[calc(100dvh-var(--subuser-preview-offset,0px))] overflow-y-auto'
+                    ? 'fixed top-[calc(4rem+var(--subuser-preview-offset,0px))] left-0 z-40 flex h-[calc(100dvh-4rem-var(--subuser-preview-offset,0px))] overflow-y-auto'
                     : 'hidden'
             }`}
         >

--- a/resources/scripts/reviactyl/components/layouts/SidebarCompact.tsx
+++ b/resources/scripts/reviactyl/components/layouts/SidebarCompact.tsx
@@ -41,9 +41,9 @@ export const SidebarCompact = React.forwardRef<HTMLDivElement, SidebarProps>(({ 
     return (
         <div
             ref={ref}
-            className={`w-[225px] self-start flex-col border border-gray-800 bg-gray-900 text-white 2xl:w-64 lg:fixed lg:top-[var(--subuser-preview-offset,0px)] lg:left-0 lg:z-40 lg:flex lg:h-[calc(100dvh-var(--subuser-preview-offset,0px))] lg:overflow-y-auto ${
+            className={`w-[225px] self-start flex-col border border-gray-800 bg-gray-900 text-white 2xl:w-64 lg:fixed lg:top-[calc(4rem+var(--subuser-preview-offset,0px))] lg:left-0 lg:z-40 lg:flex lg:h-[calc(100dvh-4rem-var(--subuser-preview-offset,0px))] lg:overflow-y-auto ${
                 isOpen
-                    ? 'fixed top-[calc(4rem+var(--subuser-preview-offset,0px))] left-0 z-40 flex h-[calc(100dvh-var(--subuser-preview-offset,0px))] overflow-y-auto'
+                    ? 'fixed top-[calc(4rem+var(--subuser-preview-offset,0px))] left-0 z-40 flex h-[calc(100dvh-4rem-var(--subuser-preview-offset,0px))] overflow-y-auto'
                     : 'hidden'
             }`}
         >

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -26,6 +26,8 @@ abstract class IntegrationTestCase extends TestCase
     {
         parent::setUp();
 
+        $this->withoutVite();
+
         Event::fake(ActivityLogged::class);
     }
 


### PR DESCRIPTION
This PR fixes an issue where the console tab in the sidebar isn't visible in servers when the layout is set to compact or accent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar positioning and sizing to account for the 4rem navigation bar.
  - Prevented sidebars from overlapping the navbar across desktop and mobile layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->