### PR TITLE
Install Composer deps before frontend build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM --platform=$BUILDPLATFORM node:22-alpine
 WORKDIR /app
 COPY . ./
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer@sha256:d8f6343d3fae98107426bc49163ccad46ef85aabd4a27d80a74401fab4aba332 /usr/bin/composer /usr/local/bin/composer
 
 RUN apk add --no-cache php php-phar php-json php-mbstring php-openssl php-tokenizer php-xml php-fileinfo php-curl php-dom php-ctype \
     && composer install --no-dev --optimize-autoloader --no-scripts --ignore-platform-reqs
@@ -21,7 +21,7 @@ FROM --platform=$TARGETOS/$TARGETARCH php:8.3-fpm-alpine
 WORKDIR /app
 COPY . ./
 COPY --from=0 /app/public/assets ./public/assets
-COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer@sha256:d8f6343d3fae98107426bc49163ccad46ef85aabd4a27d80a74401fab4aba332 /usr/bin/composer /usr/local/bin/composer
 RUN apk add --no-cache --update ca-certificates dcron curl git supervisor tar unzip nginx libpng-dev libxml2-dev libzip-dev certbot certbot-nginx freetype-dev libjpeg-turbo-dev icu-dev mysql-client \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-configure zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@
 FROM --platform=$BUILDPLATFORM node:22-alpine
 WORKDIR /app
 COPY . ./
+
+RUN apk add --no-cache php php-phar php-json php-mbstring php-openssl php-tokenizer php-xml php-fileinfo php-curl php-dom php-ctype curl \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer install --no-dev --optimize-autoloader --no-scripts --ignore-platform-reqs
+
 RUN npm install -g pnpm \
     && pnpm install --frozen-lockfile \
     && pnpm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@
 FROM --platform=$BUILDPLATFORM node:22-alpine
 WORKDIR /app
 COPY . ./
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
-RUN apk add --no-cache php php-phar php-json php-mbstring php-openssl php-tokenizer php-xml php-fileinfo php-curl php-dom php-ctype curl \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN apk add --no-cache php php-phar php-json php-mbstring php-openssl php-tokenizer php-xml php-fileinfo php-curl php-dom php-ctype \
     && composer install --no-dev --optimize-autoloader --no-scripts --ignore-platform-reqs
 
 RUN npm install -g pnpm \
@@ -21,11 +21,11 @@ FROM --platform=$TARGETOS/$TARGETARCH php:8.3-fpm-alpine
 WORKDIR /app
 COPY . ./
 COPY --from=0 /app/public/assets ./public/assets
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 RUN apk add --no-cache --update ca-certificates dcron curl git supervisor tar unzip nginx libpng-dev libxml2-dev libzip-dev certbot certbot-nginx freetype-dev libjpeg-turbo-dev icu-dev mysql-client \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-configure zip \
     && docker-php-ext-install bcmath gd intl pdo_mysql zip \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && cp .env.example .env \
     && mkdir -p bootstrap/cache/ storage/logs storage/framework/sessions storage/framework/views storage/framework/cache \
     && chmod 777 -R bootstrap storage \

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -56,6 +56,9 @@ services:
       - cache
     volumes:
       - "/srv/reviactyl/var/:/app/var/"
+      - "/srv/reviactyl/extensions/:/app/extensions/"
+      - "/srv/reviactyl/public-extensions/:/app/public/extensions/"
+      - "/srv/reviactyl/storage-extensions/:/app/storage/extensions/"
       - "/srv/reviactyl/nginx/:/etc/nginx/http.d/"
       - "/srv/reviactyl/certs/:/etc/letsencrypt/"
       - "/srv/reviactyl/logs/:/app/storage/logs"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container build reliability by using a fixed Composer image version.
  * Removed the Composer installer and associated download utility from the build process.
  * PHP dependency installation remains unchanged, including optimized production installations without development packages.

* **Configuration**
  * Added example Docker Compose volume mappings for application, public, and storage extensions, enabling extensions to be managed from host directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->